### PR TITLE
Revise local blog launch instructions

### DIFF
--- a/.github/agents/CustomEngineAgent.agent.md
+++ b/.github/agents/CustomEngineAgent.agent.md
@@ -39,9 +39,10 @@ Read the file at /.github/instructions/posts.instructions.md and use it to execu
 # Launch
 When the user requests to launch the blog locally, follow these steps:
 1. Ensure the ruby path is included in the process PATH environment variable.
-2. Execute the command `bundle exec jekyll serve` in the terminal at the root of the repository.
-3. Inform the user it'll take around 30 seconds for the 'server running' message to appear.  Monitor the terminal output intelligently, do not blindly sleep and wait.
-4. Once the server is running, launch a browser in a separate terminal session pointed at the server address
+2. Execute the command `bundle exec jekyll serve` at the root of the repository using `isBackground=true`. This returns a terminal ID.
+3. Store the terminal ID returned from step 2. Use ONLY `get_terminal_output` with this terminal ID to monitor the server's progress.
+4. Inform the user it'll take around 30 seconds for the 'server running' message to appear. Poll the terminal output intelligently using get_terminal_output, do not blindly sleep and wait.
+5. Once the server is running, use `start http://127.0.0.1:4000/mcscatblog/` in a new, completely independent terminal session to launch the browser. This command spawns a new independent process that will not affect the Jekyll server running in the background terminal.
 
 # Stop
 If the user asks to stop the local blog server, terminate the terminal process running the `bundle exec jekyll serve` command.


### PR DESCRIPTION
Updated launch steps for the local blog server to include background execution and terminal ID management.