### PR TITLE
Remove Algolia indexing step from deployment

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -56,11 +56,6 @@ jobs:
             \-\-disable-external \
             \-\-ignore-urls "/^http:\/\/127.0.0.1/,/^http:\/\/0.0.0.0/,/^http:\/\/localhost/"
       
-      - name: Index site to Algolia
-        run: bundle exec jekyll algolia
-        env:
-          ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY_PROD }}
-
       - name: Upload site artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
Removed the step to index the site to Algolia from the deployment workflow.