### PR TITLE
Disable PWA to remove stale content prompts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -122,9 +122,9 @@ assets:
     env: # [development | production]
 
 pwa:
-  enabled: true # The option for PWA feature (installable)
+  enabled: false # The option for PWA feature (installable)
   cache:
-    enabled: true # The option for PWA offline cache
+    enabled: false # The option for PWA offline cache
     # Paths defined here will be excluded from the PWA cache.
     # Usually its value is the `baseurl` of another website that
     # shares the same domain name as the current website.


### PR DESCRIPTION
## Summary
- Disables PWA feature and service worker cache in `_config.yml`
- Users will no longer see "get updated content" prompts
- Content is served fresh from the server instead of cached

## Test plan
- [ ] Verify site builds successfully
- [ ] Confirm no service worker registration on deployed site

🤖 Generated with [Claude Code](https://claude.com/claude-code)