### PR TITLE
Fix webchat-embed post date (UTC timezone)

### DIFF
--- a/_posts/2026-01-26-webchat-embed-zero-javascript.md
+++ b/_posts/2026-01-26-webchat-embed-zero-javascript.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Embedding WebChat Without Writing a Single Line of JavaScript"
-date: 2026-01-27
+date: 2026-01-26
 categories: [copilot-studio, webchat]
 tags: [webchat, copilot-studio, embedding, javascript, html, cdn, unauthenticated-agents, widget]
 description: "A new library that lets you embed BotFramework WebChat into any website using only HTML data attributes. No JavaScript knowledge required."


### PR DESCRIPTION
The post date was Jan 27 but GitHub Actions runs in UTC where it's still Jan 26, so Jekyll treated it as a future post and didn't publish it.