### PR TITLE
Fix authors page post URLs

### DIFF
--- a/_tabs/authors.md
+++ b/_tabs/authors.md
@@ -24,7 +24,7 @@ excerpt_separator: ""
   <ul class="author-posts">
     {% for post in author.items %}
     <li>
-      <a href="{{ post.url }}">{{ post.title }}</a>
+      <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
       <time>{{ post.date | date: "%b %d, %Y" }}</time>
     </li>
     {% endfor %}


### PR DESCRIPTION
## Summary
- Fixes broken post URLs on the Authors page by using `relative_url` filter
- This prepends the baseurl (`/mcscatblog/`) to post links

## Test plan
- [ ] Verify GitHub Actions build passes
- [ ] Check that post links on /authors/ page work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)