### PR TITLE
Add social preview image to Authors page

### DIFF
--- a/_tabs/authors.md
+++ b/_tabs/authors.md
@@ -4,6 +4,7 @@ title: Authors
 icon: fas fa-feather-alt
 order: 5
 excerpt_separator: ""
+image: /assets/img/customengine.png
 ---
 
 <div class="authors-grid">


### PR DESCRIPTION
## Summary
- Adds `image: /assets/img/customengine.png` to Authors page front matter
- Prevents LinkedIn from using the first author avatar as the preview image when sharing

## Test plan
- [x] Verified locally that the image doesn't render on the page itself
- [x] Confirmed og:image meta tag is set correctly

🤖 Generated with [Claude Code](https://claude.ai/code)