### PR TITLE
Fix social metadata placeholders in config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,20 +27,14 @@ github:
   username: microsoft
 
 twitter:
-  username: twitter_username # change to your Twitter username
+  username: MSPowerPlat
 
 social:
-  # Change to your full name.
-  # It will be displayed as the default author of the posts and the copyright owner in the Footer
   name: Microsoft Copilot Studio CAT
-  email: adileibowitz@microsoft.com # change to your email address
+  email: adileibowitz@microsoft.com
   links:
-    # The first element serves as the copyright owner's link
-    - https://twitter.com/username # change to your Twitter homepage
-    - https://github.com/username # change to your GitHub homepage
-    # Uncomment below to add more social links
-    # - https://www.facebook.com/username
-    # - https://www.linkedin.com/in/username
+    - https://github.com/microsoft/mcscatblog
+    - https://twitter.com/MSPowerPlat
 
 # Site Verification Settings
 webmaster_verifications:
@@ -100,7 +94,7 @@ avatar: /assets/img/paw.png
 
 # The URL of the site-wide social preview image used in SEO `og:image` meta tag.
 # It can be overridden by a customized `page.image` in front matter.
-social_preview_image: # string, local or CORS resources
+social_preview_image: /assets/img/customengine.png
 
 # boolean type, the global switch for TOC in posts.
 toc: true


### PR DESCRIPTION
## Summary
- Set `social_preview_image` to `customengine.png` (was empty)
- Set twitter username to `MSPowerPlat` (was placeholder)
- Fix social links to actual repo and Twitter URLs

These were leftover placeholders from initial theme setup.

🤖 Generated with [Claude Code](https://claude.ai/code)