### PR TITLE
Fix front matter regex in comment notification workflow

### DIFF
--- a/.github/workflows/notify-author-on-comment.yml
+++ b/.github/workflows/notify-author-on-comment.yml
@@ -48,7 +48,7 @@ jobs:
 
             // Read the post file and extract author and title from front matter
             const postContent = fs.readFileSync(path.join(postsDir, postFile), 'utf8');
-            const frontMatterMatch = postContent.match(/^---\n([\s\S]*?)\n---/);
+            const frontMatterMatch = postContent.match(/^---[ \t]*\n([\s\S]*?)\n---/);
 
             if (!frontMatterMatch) {
               console.log('Could not parse front matter');


### PR DESCRIPTION
## Summary

Fixes the front matter parsing regex to handle trailing whitespace after `---`.

Some posts have `--- ` (with trailing spaces) which caused the regex `^---\n` to fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)