### PR TITLE
Fix author block regex in comment notification

### DIFF
--- a/.github/workflows/notify-author-on-comment.yml
+++ b/.github/workflows/notify-author-on-comment.yml
@@ -79,7 +79,7 @@ jobs:
             // authorkey:
             //   ...
             //   avatar: https://github.com/username.png
-            const authorBlockRegex = new RegExp(`^${authorKey}:\\s*\\n([\\s\\S]*?)(?=^\\w|$)`, 'm');
+            const authorBlockRegex = new RegExp(`^${authorKey}:\\\\s*\\\\n((?:[ \\\\t]+.*\\\\n?)*)`, 'm');
             const authorBlockMatch = authorsContent.match(authorBlockRegex);
 
             if (!authorBlockMatch) {


### PR DESCRIPTION
## Summary

Fixes the regex that parses `authors.yml` to capture the full author block, not just the first line.

**Problem:** The regex `([\s\S]*?)(?=^\w|$)` was matching lazily and stopping after the first line, so the `avatar` field was never captured.

**Solution:** Changed to `((?:[ \t]+.*\n?)*)` which captures all indented lines belonging to that author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)