### PR TITLE
Fix regex escaping in comment notification

### DIFF
--- a/.github/workflows/notify-author-on-comment.yml
+++ b/.github/workflows/notify-author-on-comment.yml
@@ -79,7 +79,7 @@ jobs:
             // authorkey:
             //   ...
             //   avatar: https://github.com/username.png
-            const authorBlockRegex = new RegExp(`^${authorKey}:\\\\s*\\\\n((?:[ \\\\t]+.*\\\\n?)*)`, 'm');
+            const authorBlockRegex = new RegExp(`^${authorKey}:\\s*\\n((?:[ \\t]+.*\\n?)*)`, 'm');
             const authorBlockMatch = authorsContent.match(authorBlockRegex);
 
             if (!authorBlockMatch) {


### PR DESCRIPTION
Fixes over-escaped regex that was looking for literal backslashes instead of whitespace/newline character classes.