### PR TITLE
Add issues write permission to comment notification

### DIFF
--- a/.github/workflows/notify-author-on-comment.yml
+++ b/.github/workflows/notify-author-on-comment.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  issues: write
+
 jobs:
   notify-author:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds `issues: write` permission so the workflow can assign issues and post comments.