### PR TITLE
Update adapter disclaimer wording

### DIFF
--- a/_posts/2026-02-20-webchat-conversation-history-m365-sdk.md
+++ b/_posts/2026-02-20-webchat-conversation-history-m365-sdk.md
@@ -194,7 +194,7 @@ Let's be transparent about what this doesn't solve:
 
 Ideally, the M365 Agents SDK would add a `getActivities()` API natively, making the storage workaround unnecessary. The adapter is designed with that future in mind: when the SDK adds history fetching, `getHistoryFromExternalStorage` becomes an optional override rather than the primary mechanism.
 
-Until then, this pattern works. Our customer shipped it, their employees are happily switching between domain specialist agents without losing their place, and nobody's staring at a blank chat window wondering where their conversation went.
+Until then, this pattern works.
 
 Have you run into this gap yourself? Are you using the M365 Agents SDK with WebChat, or still on Direct Line? I'd love to hear about your experience in the comments.
 


### PR DESCRIPTION
## Summary

- Reword the adapter warning box to emphasize open-source ownership: "If you use it, you own the code"

🤖 Generated with [Claude Code](https://claude.com/claude-code)