### PR TITLE
Update CopilotStudioSamples links to new repo structure

### DIFF
--- a/_posts/2025-10-29-mcp-tools-resources.md
+++ b/_posts/2025-10-29-mcp-tools-resources.md
@@ -31,7 +31,7 @@ This design enables scalability—imagine a documentation system with 10,000 art
 
 ## The Biological Species Sample
 
-The new [search-species-resources-typescript](https://github.com/microsoft/CopilotStudioSamples/tree/main/MCPSamples/search-species-resources-typescript) sample demonstrates this pattern with a practical example. It provides information about animal species through search-based discovery.
+The new [search-species-resources-typescript](https://microsoft.github.io/CopilotStudioSamples/extensibility/mcp/search-species-resources-typescript) sample demonstrates this pattern with a practical example. It provides information about animal species through search-based discovery.
 
 **What's in the sample:**
 - 5 species (African Elephant, Monarch Butterfly, Great White Shark, Red Panda, Blue Whale)
@@ -170,7 +170,7 @@ To get started quickly:
 1. **Clone the repository**
    ```bash
    git clone https://github.com/microsoft/CopilotStudioSamples.git
-   cd CopilotStudioSamples/MCPSamples/search-species-resources-typescript
+   cd CopilotStudioSamples/extensibility/mcp/search-species-resources-typescript
    ```
 
 2. **Install dependencies**
@@ -245,7 +245,7 @@ This means you can:
 
 ## Try It Yourself
 
-Clone the [search-species-resources-typescript sample](https://github.com/microsoft/CopilotStudioSamples/tree/main/MCPSamples/search-species-resources-typescript) and experiment with your Copilot Studio agent. Try:
+Clone the [search-species-resources-typescript sample](https://microsoft.github.io/CopilotStudioSamples/extensibility/mcp/search-species-resources-typescript) and experiment with your Copilot Studio agent. Try:
 
 ---
 

--- a/_posts/2025-11-05-show-reasoning-agents-sdk.md
+++ b/_posts/2025-11-05-show-reasoning-agents-sdk.md
@@ -20,7 +20,7 @@ Copilot Studio agents using Anthropic models can expose their reasoning steps—
 {: .prompt-info }
 
 ## Our example
-In some steps of this tutorial, we will refer to a fully working example that can be found here: [Thinking-Activities-Sample](https://github.com/microsoft/CopilotStudioSamples/tree/main/ShowReasoningSample).  
+In some steps of this tutorial, we will refer to a fully working example that can be found here: [Thinking-Activities-Sample](https://microsoft.github.io/CopilotStudioSamples/ui/custom-ui/reasoning-display).  
 This example shows a Copilot Studio agent triggered via the Microsoft 365 Agents SDK directly from a custom UI. To keep things simple, we used a static HTML+JS website.  
 The demo scenario features an organization that uses monday.com to log its tickets. They implemented an intake form for receiving tickets and an agent that triages them using the monday.com certified MCP server. If a similar ticket is found, the new intake request is merged as an update to the existing ticket; otherwise, a new ticket is opened.
 
@@ -81,7 +81,7 @@ Typical timeline:
 
 ## Implementation Walkthrough
 
-The snippets below show the core pattern. Not all function implementations are shown here. A complete, runnable sample demoing a ticket triage system is available at [Thinking-Activities-Sample](https://github.com/microsoft/CopilotStudioSamples/tree/main/ShowReasoningSample).
+The snippets below show the core pattern. Not all function implementations are shown here. A complete, runnable sample demoing a ticket triage system is available at [Thinking-Activities-Sample](https://microsoft.github.io/CopilotStudioSamples/ui/custom-ui/reasoning-display).
 
 ### 1) Initialize the client
 
@@ -228,7 +228,7 @@ Refer to the [demo video](#our-example) for a demonstration.
 
 ## Try It Yourself
 
-- Clone the reference implementation at [Thinking-Activities-Sample](https://github.com/microsoft/CopilotStudioSamples/tree/main/ShowReasoningSample)
+- Clone the reference implementation at [Thinking-Activities-Sample](https://microsoft.github.io/CopilotStudioSamples/ui/custom-ui/reasoning-display)
 - Configure an Anthropic model for the agent in Copilot Studio  
 - Run locally, observe typing/informative streams, and integrate the summarizer
 

--- a/_posts/2025-11-25-mcp-resources-as-tool-inputs.md
+++ b/_posts/2025-11-25-mcp-resources-as-tool-inputs.md
@@ -129,7 +129,7 @@ No massive JSON in the context window and no token-heavy strings slowing everyth
 ## The sample scenario: random characters generator and counter  
   
 Let's use the sample MCP server from this repo:    
-[Github.com: Microsoft/CopilotStudioSamples](https://github.com/microsoft/CopilotStudioSamples/tree/main/MCPSamples/pass-resources-as-inputs)  
+[Github.com: Microsoft/CopilotStudioSamples](https://microsoft.github.io/CopilotStudioSamples/extensibility/mcp/pass-resources-as-inputs)  
   
 It exposes two tools:  
   
@@ -291,7 +291,7 @@ A few practical tips when applying this pattern:
 To see this pattern live:  
   
 1. Clone the sample:    
-   [Github.com: Microsoft/CopilotStudioSamples](https://github.com/microsoft/CopilotStudioSamples/tree/main/MCPSamples/pass-resources-as-inputs)     
+   [Github.com: Microsoft/CopilotStudioSamples](https://microsoft.github.io/CopilotStudioSamples/extensibility/mcp/pass-resources-as-inputs)     
 2. Deploy the MCP server as described in the repo.    
 3. Connect it to your Copilot Studio agent.    
 4. Run your tests    

--- a/_posts/2025-11-27-copilot-studio-handover-live-agent.md
+++ b/_posts/2025-11-27-copilot-studio-handover-live-agent.md
@@ -33,7 +33,7 @@ It's architectural redundancy that adds complexity without adding value.
 
 What if Copilot Studio could stay in control of its native channels while still enabling bidirectional communication with your customer service system? 
 
-That's exactly why we published a sample with a new pattern: [Copilot Studio Handover Sample](https://github.com/microsoft/CopilotStudioSamples/tree/main/IntegrateWithEngagementHub/HandoverToLiveAgentUsingSkill)
+That's exactly why we published a sample with a new pattern: [Copilot Studio Handover Sample](https://microsoft.github.io/CopilotStudioSamples/contact-center/servicenow/HandoverToLiveAgentUsingSkill)
 
 Using M365 Agents SDK skills and Microsoft Teams proactive messaging, this approach lets you:
 
@@ -87,7 +87,7 @@ The magic here is **Microsoft Teams proactive messaging**, which enables live ag
 
 ## The Sample
 
-The [Copilot Studio Handover Sample](https://github.com/microsoft/CopilotStudioSamples/tree/main/IntegrateWithEngagementHub/HandoverToLiveAgentUsingSkill) includes three components:
+The [Copilot Studio Handover Sample](https://microsoft.github.io/CopilotStudioSamples/contact-center/servicenow/HandoverToLiveAgentUsingSkill) includes three components:
 
 **1. HandoverToLiveAgentSample** - An M365 Agents SDK skill that acts as the message broker between Copilot Studio and your live chat system. It handles:
 - Authentication with both Copilot Studio and your live chat platform
@@ -109,7 +109,7 @@ Think of this as a stand-in for your actual ServiceNow, Salesforce, Genesys, or 
 
 ## Getting Started
 
-The [GitHub repository](https://github.com/microsoft/CopilotStudioSamples/tree/main/IntegrateWithEngagementHub/HandoverToLiveAgentUsingSkill) includes everything you need to try this pattern.
+The [GitHub repository](https://microsoft.github.io/CopilotStudioSamples/contact-center/servicenow/HandoverToLiveAgentUsingSkill) includes everything you need to try this pattern.
 
 At a high level, you'll need to:
 
@@ -122,7 +122,7 @@ The README provides detailed step-by-step instructions for local development, te
 
 ## Try It Out
 
-Ready to explore this pattern? Check out the [complete sample on GitHub](https://github.com/microsoft/CopilotStudioSamples/tree/main/IntegrateWithEngagementHub/HandoverToLiveAgentUsingSkill).
+Ready to explore this pattern? Check out the [complete sample on GitHub](https://microsoft.github.io/CopilotStudioSamples/contact-center/servicenow/HandoverToLiveAgentUsingSkill).
 
 Have questions or built something cool with this pattern? Drop a comment below—I'd love to hear about it!
 

--- a/_posts/2025-12-02-copilot-studio-a2a-multi-agents.md
+++ b/_posts/2025-12-02-copilot-studio-a2a-multi-agents.md
@@ -25,7 +25,7 @@ In this quickstart we'll focus on the last one: **connecting an A2A-enabled agen
 To keep things concrete, we'll use as connected agent a sample that I built with the [Microsoft Agent Framework](https://learn.microsoft.com/en-us/agent-framework/overview/agent-framework-overview) that exposes A2A. Don't be scared, Agent Framework is not a prerequisite for A2A, but simply a choice that I made in order to have something that exposes A2A ready to be plugged in Copilot Studio. You can use any A2A enabled agent that you already have.  
   
 If you don't have any A2A agent, you can clone my GitHub repo for the sample agent.
-[Microsoft Copilot Studio A2A Samples | GitHub](https://github.com/microsoft/CopilotStudioSamples/tree/main/A2ASamples/Simple-A2A-Sample)
+[Microsoft Copilot Studio A2A Samples | GitHub](https://microsoft.github.io/CopilotStudioSamples/extensibility/a2a/Simple-A2A-Sample)
   
 We'll go end-to-end:  
   

--- a/_posts/2026-01-16-response-analysis-copilot-tool.md
+++ b/_posts/2026-01-16-response-analysis-copilot-tool.md
@@ -225,7 +225,7 @@ yield (
 
 ## 🎬 The Feature Presentation: Complete Working Tool
 
-A fully functional version of this tool is available in the publicly available [ResponseAnalysisAgentsSDK](https://github.com/microsoft/CopilotStudioSamples/tree/main/FunctionalTesting/ResponseAnalysisAgentsSDK) repository. 
+A fully functional version of this tool is available in the publicly available [ResponseAnalysisAgentsSDK](https://microsoft.github.io/CopilotStudioSamples/testing/functional/ResponseAnalysisAgentsSDK) repository. 
 The codebase is ready for use and includes comprehensive instructions on initial environment setup, execution of tests, and the technical interpretation of the results. 
 
 !["Copilot Studio Response Analysis Screen Stats"](/assets/posts/response-analysis-tool/Screen-Statistics.png)
@@ -239,7 +239,7 @@ Before you rush off to try and implement this, let's be honest about a few thing
 > The current implementation is designed exclusively for single-session analysis.
 {: .prompt-warning}
 
-> Before deploying the tool, review the [requirements](https://github.com/microsoft/CopilotStudioSamples/tree/main/FunctionalTesting/ResponseAnalysisAgentsSDK#prerequisite) to ensure your environment is compatible, then execute the [setup steps](https://github.com/microsoft/CopilotStudioSamples/tree/main/FunctionalTesting/ResponseAnalysisAgentsSDK#step-1-create-an-agent-in-copilot-studio) to configure the tool.
+> Before deploying the tool, review the [requirements](https://microsoft.github.io/CopilotStudioSamples/testing/functional/ResponseAnalysisAgentsSDK#prerequisite) to ensure your environment is compatible, then execute the [setup steps](https://microsoft.github.io/CopilotStudioSamples/testing/functional/ResponseAnalysisAgentsSDK#step-1-create-an-agent-in-copilot-studio) to configure the tool.
 {: .prompt-warning}
 
 > Never commit access tokens or credentials to source control. Always use environment variables or secure credential stores, and implement proper token refresh logic.

--- a/_posts/2026-02-24-servicenow-copilot-studio-widget.md
+++ b/_posts/2026-02-24-servicenow-copilot-studio-widget.md
@@ -100,7 +100,7 @@ This means the widget works with **any** ServiceNow authentication configuration
 Nobody wants to manually create a dozen ServiceNow records. So we built a deployment script.
 
 ```bash
-cd ServiceNowWidget
+cd ui/embed/servicenow-widget
 npm install
 npm run build
 
@@ -119,7 +119,7 @@ It's **idempotent**. Run it once to set up, run it again after code changes to u
 
 ## The Sample
 
-The full sample is available in the [CopilotStudioSamples](https://github.com/microsoft/CopilotStudioSamples/tree/main/ServiceNowWidget) repo. It includes:
+The full sample is available in the [CopilotStudioSamples](https://microsoft.github.io/CopilotStudioSamples/ui/embed/servicenow-widget) repo. It includes:
 
 - **TypeScript source** for the widget (auth, bubble UI, WebChat initialization)
 - **ServiceNow widget files** (HTML, client JS, server JS, SCSS) ready to copy into the widget editor

--- a/_posts/2026-03-02-copilot-studio-api-decision-guide.md
+++ b/_posts/2026-03-02-copilot-studio-api-decision-guide.md
@@ -432,7 +432,7 @@ The trade-off? When authentication is configured, the Microsoft-hosted embed use
 ## Self-Hosted WebChat (Employee-Facing)
 {: #self-hosted-webchat-employee-facing}
 
-This is the most common pattern for custom-branded agent experiences. You host the `botframework-webchat` library yourself, giving you full control over styling, behavior, and authentication. And it's not limited to standalone web apps. The same WebChat component can be embedded natively in [SharePoint](https://github.com/microsoft/CopilotStudioSamples/tree/main/SSOSamples/SharePointSSOAppCustomizer), [ServiceNow](https://github.com/microsoft/CopilotStudioSamples/tree/main/ServiceNowWidget) (see our [field report]({% post_url 2026-02-24-servicenow-copilot-studio-widget %})), or any platform that can host JavaScript.
+This is the most common pattern for custom-branded agent experiences. You host the `botframework-webchat` library yourself, giving you full control over styling, behavior, and authentication. And it's not limited to standalone web apps. The same WebChat component can be embedded natively in [SharePoint](https://microsoft.github.io/CopilotStudioSamples/ui/embed/sharepoint-customizer/SharePointSSOAppCustomizer), [ServiceNow](https://microsoft.github.io/CopilotStudioSamples/ui/embed/servicenow-widget) (see our [field report]({% post_url 2026-02-24-servicenow-copilot-studio-widget %})), or any platform that can host JavaScript.
 
 The core pattern is almost always the same. You import the WebChat library, create a connection to your agent (more on the options below), and hand it to WebChat:
 
@@ -474,7 +474,7 @@ Direct Line is still a valid choice if you specifically need manual authenticati
 **Official samples and docs:**
 
 - **WebChat customization:** [Customize your chat canvas](https://learn.microsoft.com/en-us/microsoft-copilot-studio/customize-default-canvas) (uses Direct Line, but the styling and customization patterns apply to both APIs)
-- **M365 Agents SDK (recommended):** [React Web Chat](https://github.com/microsoft/Agents/tree/main/samples/nodejs/copilotstudio-webchat-react), [Web Client](https://github.com/microsoft/Agents/tree/main/samples/nodejs/copilotstudio-webclient), [SharePoint SSO](https://github.com/microsoft/CopilotStudioSamples/tree/main/SSOSamples/SharePointSSOAppCustomizer), [ServiceNow Widget](https://github.com/microsoft/CopilotStudioSamples/tree/main/ServiceNowWidget)
+- **M365 Agents SDK (recommended):** [React Web Chat](https://github.com/microsoft/Agents/tree/main/samples/nodejs/copilotstudio-webchat-react), [Web Client](https://github.com/microsoft/Agents/tree/main/samples/nodejs/copilotstudio-webclient), [SharePoint SSO](https://microsoft.github.io/CopilotStudioSamples/ui/embed/sharepoint-customizer/SharePointSSOAppCustomizer), [ServiceNow Widget](https://microsoft.github.io/CopilotStudioSamples/ui/embed/servicenow-widget)
 - **Direct Line with Entra SSO:** [Configure SSO for web apps](https://learn.microsoft.com/en-us/microsoft-copilot-studio/configure-sso?tabs=webApp)
 
 **When to use this:** Internal web apps, SharePoint sites, ServiceNow portals, or any employee-facing platform where you need styling control and authenticated access to your agent.
@@ -488,7 +488,7 @@ Direct Line is still a valid choice if you specifically need manual authenticati
 
 Maybe WebChat isn't your thing. Maybe your team already has a React design system, you're deep into a framework like [Assistant UI](https://www.assistant-ui.com/) or the [Vercel AI SDK](https://sdk.vercel.ai/), and the idea of wrapping a Microsoft chat component doesn't fit your architecture. That's a valid position, and Copilot Studio supports it.
 
-The connection layer is the same M365 Agents SDK client [discussed above](#self-hosted-webchat-employee-facing), with the same authentication and streaming benefits. The difference is that instead of handing the connection to WebChat, you wire it into your own components. The [Assistant UI + Copilot Studio sample](https://github.com/microsoft/CopilotStudioSamples/tree/main/AssistantUICopilotStudioClient/assistant-ui-mcs) shows what this looks like: a React app using Assistant UI components connected to a Copilot Studio agent through the SDK.
+The connection layer is the same M365 Agents SDK client [discussed above](#self-hosted-webchat-employee-facing), with the same authentication and streaming benefits. The difference is that instead of handing the connection to WebChat, you wire it into your own components. The [Assistant UI + Copilot Studio sample](https://microsoft.github.io/CopilotStudioSamples/ui/custom-ui/assistant-ui/assistant-ui-mcs) shows what this looks like: a React app using Assistant UI components connected to a Copilot Studio agent through the SDK.
 
 The trade-off: WebChat handles adaptive cards, suggested actions, file attachments, typing indicators, and dozens of Bot Framework activity types out of the box. When you bring your own UI, you're responsible for all of that. If your agent sends an adaptive card and your custom UI doesn't render it, the user sees nothing (or worse, raw JSON). And WebChat itself is [heavily customizable](https://github.com/microsoft/BotFramework-WebChat/tree/main/samples/06.recomposing-ui). We'll dig deeper into this comparison in an upcoming WebChat series.
 
@@ -551,7 +551,7 @@ The most straightforward way to embed a chat experience in your customer-facing 
 
 Not every agent experience is a chat window. Maybe you want a search box that sends a query to your Copilot Studio agent and displays the answer inline, or a product page that pulls a recommendation without any visible chat UI. For these scenarios, you can call Direct Line directly from your own components.
 
-The [Direct Line JS sample](https://github.com/microsoft/CopilotStudioSamples/tree/main/DirectLineJSSample) shows this pattern: a lightweight JavaScript client that talks to Direct Line without any WebChat dependency. You send activities, receive responses, and render them however you want.
+The [Direct Line JS sample](https://microsoft.github.io/CopilotStudioSamples/ui/custom-ui/directline-js) shows this pattern: a lightweight JavaScript client that talks to Direct Line without any WebChat dependency. You send activities, receive responses, and render them however you want.
 
 > Before going this route, remember that WebChat is [heavily customizable](https://github.com/microsoft/BotFramework-WebChat/tree/main/samples/06.recomposing-ui). You can strip it down, replace components, or restyle it completely. But if what you're building doesn't resemble a chat interface at all, Direct Line without WebChat is the right call.
 {: .prompt-tip }

--- a/_posts/2026-03-13-salesforce-copilot-studio-handoff.md
+++ b/_posts/2026-03-13-salesforce-copilot-studio-handoff.md
@@ -29,7 +29,7 @@ The docs page now includes everything you need to go from zero to a working inte
 - **Step-by-step Einstein Bot dialog setup** with screenshots showing exactly how to wire the Welcome and Confused dialogs
 - **Deployment scripts** (Bash and PowerShell) that handle everything in one shot
 
-All the code lives in the [CopilotStudioSamples repo](https://github.com/microsoft/CopilotStudioSamples/tree/main/IntegrateWithEngagementHub/Salesforce), so you can clone it, inspect it, and modify it to fit your needs.
+All the code lives in the [CopilotStudioSamples repo](https://microsoft.github.io/CopilotStudioSamples/contact-center/servicenow/Salesforce), so you can clone it, inspect it, and modify it to fit your needs.
 
 ## How the Integration Works
 
@@ -64,7 +64,7 @@ sf org login web
 
 # Clone the sample and run the deployment
 git clone https://github.com/microsoft/CopilotStudioSamples.git
-cd CopilotStudioSamples/IntegrateWithEngagementHub/Salesforce
+cd CopilotStudioSamples/contact-center/servicenow/Salesforce
 ./scripts/deploy.sh
 ```
 


### PR DESCRIPTION
## Summary
- Migrates 25 sample URLs across 9 blog posts from old CopilotStudioSamples folder paths to the reorganized structure
- URLs now point to `microsoft.github.io/CopilotStudioSamples/` (GitHub Pages site)
- Code block `cd` paths also updated to match new repo layout

## Affected posts
- `salesforce-copilot-studio-handoff`
- `copilot-studio-handover-live-agent`
- `response-analysis-copilot-tool`
- `show-reasoning-agents-sdk`
- `mcp-tools-resources`
- `mcp-resources-as-tool-inputs`
- `copilot-studio-api-decision-guide`
- `servicenow-copilot-studio-widget`
- `copilot-studio-a2a-multi-agents`

## Test plan
- [ ] Verify links resolve correctly on the published site
- [ ] Spot-check a few URLs against the live GitHub Pages site

🤖 Generated with [Claude Code](https://claude.com/claude-code)