### PR TITLE
Fix rendering and update title for Teams agent patterns post

### DIFF
--- a/_posts/2026-04-07-copilot-studio-teams-agent-patterns.md
+++ b/_posts/2026-04-07-copilot-studio-teams-agent-patterns.md
@@ -1,10 +1,10 @@
 ---
 layout: post
-title: "Deploying Copilot Studio Agents in Teams (Because Test Chat Was Too Easy)"
+title: "Design Copilot Studio Agents for Teams (Because Test Chat Was Too Easy)"
 date: 2026-04-07
 categories: [copilot-studio, teams]
 tags: [teams, microsoft-365-copilot, conversation-management, troubleshooting, adaptive-cards]
-description: Eight production patterns for deploying Copilot Studio agents to Teams and Microsoft 365 Copilot - handling reinstalls, context management, error handling, and self-service troubleshooting with diagnostic cards.
+description: Eight production patterns for designing Copilot Studio agents that work well in Teams and Microsoft 365 Copilot - handling reinstalls, context management, error handling, and self-service troubleshooting with diagnostic cards.
 author: henryjammes
 image:
   path: /assets/posts/copilot-studio-teams-agent-patterns/header.png
@@ -67,7 +67,7 @@ Agent conversations in Teams are persistent. Users return after a week and the a
 
 Set an [inactivity trigger](https://learn.microsoft.com/microsoft-copilot-studio/authoring-system-triggers#inactivity) (in seconds) to end topics and clear [history and variables](https://learn.microsoft.com/microsoft-copilot-studio/authoring-variables) after silence. Once you've cleared everything, set a flag (`Global.InactiveConversation`) to handle follow-up smoothly.
 
-<details>
+<details markdown="1">
 <summary>Full YAML — click to expand</summary>
 
 ```yaml


### PR DESCRIPTION
Update title to reflect design guidance focus rather than deployment, and add missing markdown="1" attribute to details block that was preventing YAML code from rendering correctly.