### PR TITLE
MCP post: InvokeServer explanation and connection wording fix

### DIFF
--- a/_posts/2026-04-10-hello-world-mcp-copilot-studio.md
+++ b/_posts/2026-04-10-hello-world-mcp-copilot-studio.md
@@ -63,7 +63,7 @@ That's it. You have a working MCP connector configured as a tool for your agent.
 
 ## What happened under the hood?
 
-When you added the MCP server through the wizard, Copilot Studio created a **custom connector** in your Power Platform environment under the hood. This connector contains an OpenAPI specification that routes requests to the MCP server's `/mcp` endpoint using the Streamable HTTP protocol.
+When you added the MCP server through the wizard, Copilot Studio created a **custom connector** in your Power Platform environment under the hood. This connector contains an OpenAPI specification with a single action called **InvokeServer**. That action is the Streamable HTTP POST that Copilot Studio sends to the MCP server's `/mcp` endpoint whenever it needs to list available tools or call one. The payload follows the JSON-RPC format that MCP uses under the hood.
 
 You can view and edit this connector in the current solution. From the agent details page, click the **...** menu, select **View solution**, and then find the "DeepWiki" Custom Connector. If you want to inspect the generated spec or make changes, click on the custom connector, then click **Edit**. This is exactly what you'd do if you needed to [add custom headers]({% post_url 2025-10-22-mcp-custom-headers %}) to your connector.
 

--- a/_posts/2026-04-10-hello-world-mcp-copilot-studio.md
+++ b/_posts/2026-04-10-hello-world-mcp-copilot-studio.md
@@ -79,7 +79,7 @@ But the wizard created more than just a custom connector. Look at the solution c
 
 ### Why do the solution component details matter? 
 
-When you use pipelines or manual export/import to more your solution into another environment (say, test or production), the custom connector and connection reference are included in the solution. However the connection does not. Someone in the target environment will need to create a new connection and map it to the connection reference. This is standard Power Platform [ALM](https://learn.microsoft.com/en-us/power-platform/alm/solution-concepts-alm), but if you're coming from an M365 background, it's easy to miss.
+When you use pipelines or manual export/import to more your solution into another environment (say, test or production), the custom connector and connection reference are included in the solution. However the connection does not. When deploying via pipelines or importing the solution, you'll be prompted to create a connection for the connection reference in the target environment. This is standard Power Platform [ALM](https://learn.microsoft.com/en-us/power-platform/alm/solution-concepts-alm), but if you're coming from an M365 background, it's easy to miss.
 
 > This same pattern applies to [A2A (Agent-to-Agent) connectors](https://learn.microsoft.com/en-us/microsoft-copilot-studio/add-agent-agent-to-agent). When you connect to an external agent over the A2A protocol, Copilot Studio creates a custom connector and connection reference in exactly the same way. Everything in this section applies to A2A.
 {: .prompt-info }

--- a/_posts/2026-04-10-hello-world-mcp-copilot-studio.md
+++ b/_posts/2026-04-10-hello-world-mcp-copilot-studio.md
@@ -81,6 +81,9 @@ But the wizard created more than just a custom connector. Look at the solution c
 
 When you use pipelines or manual export/import to more your solution into another environment (say, test or production), the custom connector and connection reference are included in the solution. However the connection does not. When deploying via pipelines or importing the solution, you'll be prompted to create a connection for the connection reference in the target environment. This is standard Power Platform [ALM](https://learn.microsoft.com/en-us/power-platform/alm/solution-concepts-alm), but if you're coming from an M365 background, it's easy to miss.
 
+> **Known limitation:** Power Platform requires custom connectors to be [in their own solution](https://learn.microsoft.com/en-us/connectors/custom-connectors/customconnectorssolutions#known-limitations) when moving across environments. The MCP wizard adds the connector to your agent's solution, so you'll need to separate it into its own solution before deploying to another environment.
+{: .prompt-warning }
+
 > This same pattern applies to [A2A (Agent-to-Agent) connectors](https://learn.microsoft.com/en-us/microsoft-copilot-studio/add-agent-agent-to-agent). When you connect to an external agent over the A2A protocol, Copilot Studio creates a custom connector and connection reference in exactly the same way. Everything in this section applies to A2A.
 {: .prompt-info }
 

--- a/_posts/2026-04-10-hello-world-mcp-copilot-studio.md
+++ b/_posts/2026-04-10-hello-world-mcp-copilot-studio.md
@@ -80,7 +80,7 @@ But the wizard created more than just a custom connector. Look at the solution c
 
 ### Why do the solution component details matter? 
 
-When you use pipelines or manual export/import to more your solution into another environment (say, test or production), the custom connector and connection reference are included in the solution. However the connection does not. When deploying via pipelines or importing the solution, you'll be prompted to create a connection for the connection reference in the target environment. This is standard Power Platform [ALM](https://learn.microsoft.com/en-us/power-platform/alm/solution-concepts-alm), but if you're coming from an M365 background, it's easy to miss.
+When you use pipelines or manual export/import to move your solution into another environment (say, test or production), the custom connector and connection reference are included in the solution. However the connection does not. When deploying via pipelines or importing the solution, you'll be prompted to create a connection for the connection reference in the target environment. This is standard Power Platform [ALM](https://learn.microsoft.com/en-us/power-platform/alm/solution-concepts-alm), but if you're coming from an M365 background, it's easy to miss.
 
 > **Known limitation:** Power Platform requires custom connectors to be [in their own solution](https://learn.microsoft.com/en-us/connectors/custom-connectors/customconnectorssolutions#known-limitations) when moving across environments. The MCP wizard adds the connector to your agent's solution, so you'll need to separate it into its own solution before deploying to another environment.
 {: .prompt-warning }

--- a/_posts/2026-04-10-hello-world-mcp-copilot-studio.md
+++ b/_posts/2026-04-10-hello-world-mcp-copilot-studio.md
@@ -82,6 +82,9 @@ But the wizard created more than just a custom connector. Look at the solution c
 
 When you use pipelines or manual export/import to more your solution into another environment (say, test or production), the custom connector and connection reference are included in the solution. However the connection does not. When deploying via pipelines or importing the solution, you'll be prompted to create a connection for the connection reference in the target environment. This is standard Power Platform [ALM](https://learn.microsoft.com/en-us/power-platform/alm/solution-concepts-alm), but if you're coming from an M365 background, it's easy to miss.
 
+> **Known limitation:** Power Platform requires custom connectors to be [in their own solution](https://learn.microsoft.com/en-us/connectors/custom-connectors/customconnectorssolutions#known-limitations) when moving across environments. The MCP wizard adds the connector to your agent's solution, so you'll need to separate it into its own solution before deploying to another environment.
+{: .prompt-warning }
+
 > This same pattern applies to [A2A (Agent-to-Agent) connectors](https://learn.microsoft.com/en-us/microsoft-copilot-studio/add-agent-agent-to-agent). When you connect to an external agent over the A2A protocol, Copilot Studio creates a custom connector and connection reference in exactly the same way. Everything in this section applies to A2A.
 {: .prompt-info }
 

--- a/_posts/2026-04-10-hello-world-mcp-copilot-studio.md
+++ b/_posts/2026-04-10-hello-world-mcp-copilot-studio.md
@@ -64,7 +64,7 @@ That's it. You have a working MCP connector configured as a tool for your agent.
 
 ## What happened under the hood?
 
-When you added the MCP server through the wizard, Copilot Studio created a **custom connector** in your Power Platform environment under the hood. This connector contains an OpenAPI specification that routes requests to the MCP server's `/mcp` endpoint using the Streamable HTTP protocol.
+When you added the MCP server through the wizard, Copilot Studio created a **custom connector** in your Power Platform environment under the hood. This connector contains an OpenAPI specification with a single action called **InvokeServer**. That action is the Streamable HTTP POST that Copilot Studio sends to the MCP server's `/mcp` endpoint whenever it needs to list available tools or call one. The payload follows the JSON-RPC format that MCP uses under the hood.
 
 You can view and edit this connector in the current solution. From the agent details page, click the **...** menu, select **View solution**, and then find the "DeepWiki" Custom Connector. If you want to inspect the generated spec or make changes, click on the custom connector, then click **Edit**. This is exactly what you'd do if you needed to [add custom headers]({% post_url 2025-10-22-mcp-custom-headers %}) to your connector.
 

--- a/_posts/2026-04-10-hello-world-mcp-copilot-studio.md
+++ b/_posts/2026-04-10-hello-world-mcp-copilot-studio.md
@@ -80,7 +80,7 @@ But the wizard created more than just a custom connector. Look at the solution c
 
 ### Why do the solution component details matter? 
 
-When you use pipelines or manual export/import to more your solution into another environment (say, test or production), the custom connector and connection reference are included in the solution. However the connection does not. Someone in the target environment will need to create a new connection and map it to the connection reference. This is standard Power Platform [ALM](https://learn.microsoft.com/en-us/power-platform/alm/solution-concepts-alm), but if you're coming from an M365 background, it's easy to miss.
+When you use pipelines or manual export/import to more your solution into another environment (say, test or production), the custom connector and connection reference are included in the solution. However the connection does not. When deploying via pipelines or importing the solution, you'll be prompted to create a connection for the connection reference in the target environment. This is standard Power Platform [ALM](https://learn.microsoft.com/en-us/power-platform/alm/solution-concepts-alm), but if you're coming from an M365 background, it's easy to miss.
 
 > This same pattern applies to [A2A (Agent-to-Agent) connectors](https://learn.microsoft.com/en-us/microsoft-copilot-studio/add-agent-agent-to-agent). When you connect to an external agent over the A2A protocol, Copilot Studio creates a custom connector and connection reference in exactly the same way. Everything in this section applies to A2A.
 {: .prompt-info }


### PR DESCRIPTION
## Summary
- Added explanation of the **InvokeServer** action in the custom connector (Streamable HTTP POST, JSON-RPC payload). Customer requested more detail on this piece.
- Clarified that connection creation is prompted during pipeline deployment or solution import (not a separate manual step).
- Added known limitation callout about putting custom connectors in a solution that is deployed beforehand. Jaime Sicre reminded me about that limitation bullet I wrote a 2-3 years ago!