### PR TITLE
Add 'teams' tag to three Teams-related posts

### DIFF
--- a/_posts/2025-11-11-copilot-studio-teams-deployment-ux.md
+++ b/_posts/2025-11-11-copilot-studio-teams-deployment-ux.md
@@ -3,7 +3,7 @@ layout: post
 title: "Best Practices for Deploying Copilot Studio Agents in Microsoft Teams"
 date: 2025-11-14 17:30:00 +0100
 categories: [copilot-studio, teams, deployment]
-tags: [teams-integration, session-management, state-management, troubleshooting]
+tags: [teams, teams-integration, session-management, state-management, troubleshooting]
 description: Essential techniques for managing session state, handling updates, and ensuring reliable performance when deploying Copilot Studio Agents to Microsoft Teams.
 author: raemone
 image:

--- a/_posts/2025-11-11-copilot-studio-teams-deployment-ux.md
+++ b/_posts/2025-11-11-copilot-studio-teams-deployment-ux.md
@@ -4,7 +4,7 @@ layout: post
 title: "Best Practices for Deploying Copilot Studio Agents in Microsoft Teams"
 date: 2025-11-14 17:30:00 +0100
 categories: [channels]
-tags: [teams-integration, session-management, state-management, troubleshooting]
+tags: [teams, teams-integration, session-management, state-management, troubleshooting]
 description: Essential techniques for managing session state, handling updates, and ensuring reliable performance when deploying Copilot Studio Agents to Microsoft Teams.
 author: raemone
 image:

--- a/_posts/2025-11-27-copilot-studio-handover-live-agent.md
+++ b/_posts/2025-11-27-copilot-studio-handover-live-agent.md
@@ -3,7 +3,7 @@ layout: post
 title: "Handing Over to Live Agents Without Losing Control"
 date: 2025-12-14
 categories: [copilot-studio, tutorial, integration]
-tags: [handover, escalation, live-chat, skills, proactive-messaging, microsoft-teams]
+tags: [teams, handover, escalation, live-chat, skills, proactive-messaging, microsoft-teams]
 description: Keep Copilot Studio in control while seamlessly handing off conversations to live agents using skills and Teams proactive messaging.
 author: mawasile    
 mermaid: true

--- a/_posts/2025-11-27-copilot-studio-handover-live-agent.md
+++ b/_posts/2025-11-27-copilot-studio-handover-live-agent.md
@@ -4,7 +4,7 @@ layout: post
 title: "Handing Over to Live Agents Without Losing Control"
 date: 2025-12-14
 categories: [channels]
-tags: [handover, escalation, live-chat, skills, proactive-messaging, microsoft-teams]
+tags: [teams, handover, escalation, live-chat, skills, proactive-messaging, microsoft-teams]
 description: Keep Copilot Studio in control while seamlessly handing off conversations to live agents using skills and Teams proactive messaging.
 author: mawasile    
 mermaid: true

--- a/_posts/2026-04-07-copilot-studio-teams-deployment.md
+++ b/_posts/2026-04-07-copilot-studio-teams-deployment.md
@@ -3,7 +3,7 @@ layout: post
 title: "From DEV to PROD: Deploying Copilot Studio Agents to Teams and Microsoft 365 Copilot"
 date: 2026-04-07
 categories: [copilot-studio, teams, deployment]
-tags: [teams-deployment, admin-center, setup-policies, app-manifest, alm, environment-strategy, auto-install, microsoft-365-copilot]
+tags: [teams, teams-deployment, admin-center, setup-policies, app-manifest, alm, environment-strategy, auto-install, microsoft-365-copilot]
 description: "Master the three deployment paths for Copilot Studio agents in Teams and Microsoft 365 Copilot. Learn how to customize manifests for DEV/TEST environments, leverage Setup Policies for auto-install and pinning, and deploy to M365 Copilot through the Admin Center."
 author: henryjammes
 image:

--- a/_posts/2026-04-07-copilot-studio-teams-deployment.md
+++ b/_posts/2026-04-07-copilot-studio-teams-deployment.md
@@ -4,7 +4,7 @@ layout: post
 title: "From DEV to PROD: Deploying Copilot Studio Agents to Teams and Microsoft 365 Copilot"
 date: 2026-04-07
 categories: [channels]
-tags: [teams-deployment, admin-center, setup-policies, app-manifest, alm, environment-strategy, auto-install, microsoft-365-copilot]
+tags: [teams, teams-deployment, admin-center, setup-policies, app-manifest, alm, environment-strategy, auto-install, microsoft-365-copilot]
 description: "Master the three deployment paths for Copilot Studio agents in Teams and Microsoft 365 Copilot. Learn how to customize manifests for DEV/TEST environments, leverage Setup Policies for auto-install and pinning, and deploy to M365 Copilot through the Admin Center."
 author: henryjammes
 image:


### PR DESCRIPTION
## Summary
The 'teams' tag had most but not all of the high value teams posts. Adding the 'teams' tag to the others for easy reference.

Posts updated:
- `copilot-studio-teams-deployment-ux.md` (had `teams-integration`)
- `copilot-studio-teams-deployment.md` (had `teams-deployment`)
- `copilot-studio-handover-live-agent.md` (had `microsoft-teams`)