### PR TITLE
Disable Google Analytics until cookie consent is resolved

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -51,7 +51,7 @@ webmaster_verifications:
 # Web Analytics Settings
 analytics:
   google:
-    id: G-M4M35T13NN
+    id: # G-M4M35T13NN (disabled until cookie consent is resolved)
   goatcounter:
     id: # fill in your GoatCounter ID
   umami:


### PR DESCRIPTION
## Summary
- Disables GA4 tracking by commenting out the measurement ID in `_config.yml`
- GA4 (gtag.js) sets first-party cookies (`_ga`, `_ga_*`) with no consent banner, which is a compliance concern
- The ID is preserved in a comment for easy re-enablement once a consent solution is in place

## Test plan
- [ ] Verify the gtag.js script no longer loads on the production site after merge
- [ ] Confirm the site builds and deploys successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)