### PR TITLE
Clear leftover GA cookies for returning visitors

### DIFF
--- a/_includes/metadata-hook.html
+++ b/_includes/metadata-hook.html
@@ -1,1 +1,10 @@
 <meta name="algolia-site-verification"  content="46C247BC7C8677B2" />
+
+<!-- Clean up GA cookies from before analytics was disabled -->
+<script>
+  (function() {
+    var dominated = '; path=/; max-age=0; domain=.microsoft.github.io';
+    document.cookie = '_ga=' + dominated;
+    document.cookie = '_ga_M4M35T13NN=' + dominated;
+  })();
+</script>


### PR DESCRIPTION
## Summary
- Adds a small inline script to `metadata-hook.html` that expires the `_ga` and `_ga_M4M35T13NN` cookies on `.microsoft.github.io`
- These cookies were set before GA was disabled in #281 and persist until 2026-2027
- Script can be removed after a few weeks once cookies have cleared across the audience

## Test plan
- [ ] Deploy and visit the blog, then check Application > Cookies in DevTools
- [ ] Verify `_ga` and `_ga_M4M35T13NN` are no longer present on `.microsoft.github.io`

🤖 Generated with [Claude Code](https://claude.com/claude-code)