### PR TITLE
Replace Google Analytics with Microsoft Clarity

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -60,6 +60,8 @@ analytics:
   matomo:
     id: # fill in your Matomo ID
     domain: # fill in your Matomo domain
+  clarity:
+    id: wrvdi3rw3l
   cloudflare:
     id: # fill in your Cloudflare Web Analytics token
   fathom:

--- a/_includes/analytics/clarity.html
+++ b/_includes/analytics/clarity.html
@@ -1,0 +1,8 @@
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+  (function(c,l,a,r,i,t,y){
+    c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+    t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+    y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+  })(window, document, "clarity", "script", "{{ site.analytics.clarity.id }}");
+</script>

--- a/_includes/metadata-hook.html
+++ b/_includes/metadata-hook.html
@@ -1,12 +1,1 @@
 <meta name="algolia-site-verification"  content="46C247BC7C8677B2" />
-
-<!-- Clean up GA cookies from before analytics was disabled -->
-<script>
-  (function() {
-    var names = ['_ga', '_ga_M4M35T13NN'];
-    var domains = ['.microsoft.github.io', 'microsoft.github.io'];
-    for (var i = 0; i < names.length; i++)
-      for (var j = 0; j < domains.length; j++)
-        document.cookie = names[i] + '=; path=/; max-age=0; domain=' + domains[j];
-  })();
-</script>


### PR DESCRIPTION
## Summary
- Adds Microsoft Clarity as the analytics provider (cookieless mode for EU/EEA visitors, full tracking elsewhere)
- Removes disabled Google Analytics config and GA cookie cleanup script
- No consent banner needed — Clarity handles EU consent automatically

## Test plan
- [x] `JEKYLL_ENV=production bundle exec jekyll build` succeeds
- [x] Clarity script with project ID `wrvdi3rw3l` appears in production build HTML
- [x] GA cookie cleanup script no longer in rendered output
- [ ] Verify pageviews appear in [clarity.microsoft.com](https://clarity.microsoft.com) after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)