### PR TITLE
Fix install.ps1 PowerShell errors

### DIFF
--- a/tools/setup/win/install.ps1
+++ b/tools/setup/win/install.ps1
@@ -2,10 +2,10 @@ $rubyPackageName = "RubyInstallerTeam.RubyWithDevKit.3.2";
 $rubyPath = (get-location).Drive.Name + ":\Ruby32-x64\bin"
 
 Write-Host "Checking for Microsoft.WinGet.Client module..."
-$wingetInstalled = winget --version | Out-Null
+$wingetInstalled = $null -ne (Get-Command winget -ErrorAction SilentlyContinue)
 
 if (-not $wingetInstalled) {
-    Write-ErrorAction "WinGet is not installed. Please install WinGet from https://aka.ms/getwinget and re-run this script."
+    Write-Error "WinGet is not installed. Please install WinGet from https://aka.ms/getwinget and re-run this script."
     Exit 1
 } else {
     Write-Host "Validated WinGet installation."


### PR DESCRIPTION
## Summary
- Replace non-existent `Write-ErrorAction` cmdlet with `Write-Error` (caused `CommandNotFoundException` when WinGet check failed)
- Fix WinGet detection: `winget --version | Out-Null` always assigned `$null` to `$wingetInstalled`, so the script always reported WinGet as missing. Replaced with `Get-Command winget` probe.

## Test plan
- [x] Run `tools/setup/win/install.ps1` on a Windows machine with WinGet installed and confirm it validates WinGet instead of erroring out
- [x] Run on a machine without WinGet and confirm a clean `Write-Error` message is shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)