### PR TITLE
Add PR blog preview workflow

### DIFF
--- a/.github/workflows/pr-blog-preview-comment.yml
+++ b/.github/workflows/pr-blog-preview-comment.yml
@@ -1,0 +1,189 @@
+name: PR Blog Preview Comment
+
+on:
+  workflow_run:
+    workflows: ["PR Blog Preview"]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  comment:
+    name: Comment on pull request
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request'
+
+    steps:
+      - name: Download preview result
+        id: download-result
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: pr-blog-preview-result
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          path: preview-result
+
+      - name: Add or update PR comment
+        if: steps.download-result.outcome == 'success' && hashFiles('preview-result/preview-result.json') != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+
+            const marker = '<!-- pr-blog-preview-comment -->';
+            const result = JSON.parse(fs.readFileSync('preview-result/preview-result.json', 'utf8'));
+            const workflowRun = context.payload.workflow_run;
+            const prNumber = workflowRun.pull_requests?.[0]?.number || result.prNumber;
+
+            if (!prNumber) {
+              core.info('No pull request number was available for this workflow run.');
+              return;
+            }
+
+            const { owner, repo } = context.repo;
+            const artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
+              owner,
+              repo,
+              run_id: workflowRun.id,
+              per_page: 100
+            });
+
+            const artifactByName = new Map(artifacts.map((artifact) => [artifact.name, artifact]));
+
+            function artifactLink(name) {
+              const artifact = artifactByName.get(name);
+              if (!artifact) {
+                return null;
+              }
+
+              return `https://github.com/${owner}/${repo}/actions/runs/${workflowRun.id}/artifacts/${artifact.id}`;
+            }
+
+            function escapeMarkdown(value) {
+              return String(value ?? '').replace(/([\\`*_{}[\]()#+\-.!|>])/g, '\\$1');
+            }
+
+            function escapeCodeFence(value) {
+              return String(value ?? '').replace(/```/g, '``\\`');
+            }
+
+            function shortSha(value) {
+              return String(value || workflowRun.head_sha || '').slice(0, 7);
+            }
+
+            function detailsBlock(title, content) {
+              if (!content) {
+                return '';
+              }
+
+              return [
+                `<details>`,
+                `<summary>${title}</summary>`,
+                '',
+                '```text',
+                escapeCodeFence(content),
+                '```',
+                '',
+                `</details>`
+              ].join('\n');
+            }
+
+            const runUrl = result.runUrl || workflowRun.html_url;
+            const htmlArtifactUrl = artifactLink(result.htmlArtifactName || 'pr-blog-preview-html');
+            const screenshotArtifactUrl = artifactLink(result.screenshotArtifactName || 'pr-blog-preview-screenshots');
+            const resultArtifactUrl = artifactLink('pr-blog-preview-result');
+
+            const addedPosts = Array.isArray(result.addedPosts) ? result.addedPosts : [];
+            const previewPages = Array.isArray(result.previewPages) ? result.previewPages : [];
+            const missingPreviews = Array.isArray(result.missingPreviews) ? result.missingPreviews : [];
+            const previewSucceeded = result.htmlSucceeded && result.screenshotSucceeded && missingPreviews.length === 0;
+
+            const lines = [marker];
+
+            if (!result.buildSucceeded) {
+              lines.push(
+                `**Blog preview check failed** for \`${shortSha(result.headSha)}\`.`,
+                '',
+                `The Jekyll site did not compile. See [the workflow run](${runUrl}) for the full logs${resultArtifactUrl ? ` or download the [result artifact](${resultArtifactUrl})` : ''}.`,
+                '',
+                detailsBlock('Build log tail', result.buildLogTail)
+              );
+            } else if (!previewSucceeded) {
+              const missingLines = missingPreviews.map((item) => {
+                const post = escapeMarkdown(item.post || '(unknown post)');
+                const reason = escapeMarkdown(item.reason || 'Preview was not generated.');
+                return `- \`${post}\`: ${reason}`;
+              });
+
+              lines.push(
+                `**Blog compiled, but preview generation failed** for \`${shortSha(result.headSha)}\`.`,
+                '',
+                `The Jekyll build completed, but one or more HTML or screenshot previews could not be generated. See [the workflow run](${runUrl})${resultArtifactUrl ? ` or the [result artifact](${resultArtifactUrl})` : ''}.`,
+                ''
+              );
+
+              if (missingLines.length > 0) {
+                lines.push('Missing previews:', ...missingLines, '');
+              }
+
+              lines.push(detailsBlock('Screenshot log tail', result.screenshotLogTail));
+            } else if (addedPosts.length === 0) {
+              lines.push(
+                `**Blog preview check passed** for \`${shortSha(result.headSha)}\`.`,
+                '',
+                `The Jekyll site compiled successfully. No newly added \`_posts/*.md\` files were detected in this PR.`
+              );
+            } else {
+              const postLines = previewPages.map((previewPage) => {
+                const post = escapeMarkdown(previewPage.post);
+                const route = escapeMarkdown(previewPage.urlPath);
+                return `- \`${post}\` -> \`${route}\``;
+              });
+
+              lines.push(
+                `**Blog preview check passed** for \`${shortSha(result.headSha)}\`.`,
+                '',
+                `The Jekyll site compiled successfully and generated previews for the newly added post${previewPages.length === 1 ? '' : 's'}.`,
+                '',
+                ...postLines,
+                '',
+                'Preview artifacts:',
+                `- Rendered HTML: ${htmlArtifactUrl ? `[download artifact](${htmlArtifactUrl})` : 'available from the workflow run artifacts'}`,
+                `- Screenshots: ${screenshotArtifactUrl ? `[download artifact](${screenshotArtifactUrl})` : 'available from the workflow run artifacts'}`,
+                '',
+                `[Open the workflow run](${runUrl})`
+              );
+            }
+
+            const body = lines.filter((line) => line !== undefined && line !== null).join('\n');
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: prNumber,
+              per_page: 100
+            });
+
+            const existing = comments.find((comment) => {
+              return comment.user?.type === 'Bot' && comment.body?.includes(marker);
+            });
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: prNumber,
+                body
+              });
+            }

--- a/.github/workflows/pr-blog-preview.yml
+++ b/.github/workflows/pr-blog-preview.yml
@@ -1,0 +1,385 @@
+name: PR Blog Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: pr-blog-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  COOLDOWN_SECONDS: 180
+  PREVIEW_BASE_URL: http://127.0.0.1:4000
+  HTML_ARTIFACT_NAME: pr-blog-preview-html
+  SCREENSHOT_ARTIFACT_NAME: pr-blog-preview-screenshots
+
+jobs:
+  build:
+    name: Build and capture previews
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Cool down for commit bursts
+        run: |
+          if [[ "$COOLDOWN_SECONDS" =~ ^[0-9]+$ ]] && (( COOLDOWN_SECONDS > 0 )); then
+            echo "Waiting ${COOLDOWN_SECONDS}s before starting the build..."
+            sleep "$COOLDOWN_SECONDS"
+          fi
+
+      - name: Check whether this run is still current
+        id: freshness
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          latest_sha="$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.sha')"
+
+          if [[ "$latest_sha" != "$EVENT_HEAD_SHA" ]]; then
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+            echo "Skipping stale run for ${EVENT_HEAD_SHA}; latest PR head is ${latest_sha}."
+            exit 0
+          fi
+
+          echo "stale=false" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        if: steps.freshness.outputs.stale != 'true'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Ruby
+        if: steps.freshness.outputs.stale != 'true'
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.3
+          bundler-cache: true
+
+      - name: Detect newly added posts
+        if: steps.freshness.outputs.stale != 'true'
+        id: detect-posts
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          gh api --paginate "repos/${REPOSITORY}/pulls/${PR_NUMBER}/files" \
+            --jq '.[] | select(.status == "added" and (.filename | test("^_posts/.*\\.md$"))) | .filename' \
+            > added-posts.txt
+
+          post_count="$(grep -c . added-posts.txt || true)"
+          echo "count=${post_count}" >> "$GITHUB_OUTPUT"
+
+          if (( post_count > 0 )); then
+            echo "New posts detected:"
+            cat added-posts.txt
+          else
+            echo "No newly added posts were detected."
+          fi
+
+      - name: Build Jekyll site
+        if: steps.freshness.outputs.stale != 'true'
+        id: build-site
+        run: |
+          set +e
+          JEKYLL_ENV=production bundle exec jekyll build \
+            -d "_site/mcscatblog" \
+            --config _config.yml \
+            > build.log 2>&1
+          status=$?
+          set -e
+
+          cat build.log
+          echo "exit_code=${status}" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Prepare rendered HTML previews
+        if: steps.build-site.outputs.exit_code == '0' && steps.detect-posts.outputs.count != '0'
+        id: html-previews
+        run: |
+          set +e
+          node <<'NODE'
+          const fs = require('fs');
+          const path = require('path');
+
+          fs.mkdirSync('preview-html', { recursive: true });
+
+          const posts = fs.readFileSync('added-posts.txt', 'utf8')
+            .split(/\r?\n/)
+            .map((line) => line.trim())
+            .filter(Boolean);
+
+          const previewPages = [];
+          const missingPreviews = [];
+
+          for (const post of posts) {
+            const fileName = path.basename(post, '.md');
+            const match = fileName.match(/^\d{4}-\d{2}-\d{2}-(.+)$/);
+
+            if (!match) {
+              missingPreviews.push({
+                post,
+                reason: 'Post filename must use YYYY-MM-DD-slug.md format.'
+              });
+              continue;
+            }
+
+            const slug = match[1];
+            const htmlPath = path.join('_site', 'mcscatblog', 'posts', slug, 'index.html');
+            const htmlArtifactPath = path.join('preview-html', `${slug}.html`);
+
+            if (!fs.existsSync(htmlPath)) {
+              missingPreviews.push({
+                post,
+                slug,
+                reason: `Expected generated page was not found at ${htmlPath}.`
+              });
+              continue;
+            }
+
+            fs.copyFileSync(htmlPath, htmlArtifactPath);
+            previewPages.push({
+              post,
+              slug,
+              htmlPath,
+              htmlArtifactPath,
+              urlPath: `/mcscatblog/posts/${slug}/`
+            });
+          }
+
+          fs.writeFileSync('preview-pages.json', `${JSON.stringify(previewPages, null, 2)}\n`);
+          fs.writeFileSync('missing-previews.json', `${JSON.stringify(missingPreviews, null, 2)}\n`);
+
+          if (missingPreviews.length > 0) {
+            console.error('Some newly added posts did not produce rendered HTML previews.');
+            console.error(JSON.stringify(missingPreviews, null, 2));
+            process.exit(1);
+          }
+
+          console.log(`Prepared ${previewPages.length} rendered HTML preview(s).`);
+          NODE
+          status=$?
+          set -e
+
+          echo "exit_code=${status}" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Capture post screenshots
+        if: steps.build-site.outputs.exit_code == '0' && steps.detect-posts.outputs.count != '0' && steps.html-previews.outputs.exit_code == '0'
+        id: screenshots
+        run: |
+          status=0
+          server_pid=""
+
+          cleanup() {
+            if [[ -n "$server_pid" ]]; then
+              kill "$server_pid" 2>/dev/null || true
+            fi
+          }
+          trap cleanup EXIT
+
+          {
+            mkdir -p preview-screenshots
+
+            ruby -run -e httpd -- --bind-address=127.0.0.1 --port=4000 _site > static-server.log 2>&1 &
+            server_pid=$!
+
+            for attempt in {1..30}; do
+              if curl -fsS "${PREVIEW_BASE_URL}/mcscatblog/" > /dev/null; then
+                break
+              fi
+
+              if (( attempt == 30 )); then
+                echo "Static preview server did not become available."
+                exit 1
+              fi
+
+              sleep 1
+            done
+
+            playwright_dir="$(mktemp -d)"
+            npm install \
+              --prefix "$playwright_dir" \
+              --no-save \
+              --no-package-lock \
+              --no-audit \
+              --no-fund \
+              playwright@1.49.1
+            "$playwright_dir/node_modules/.bin/playwright" install --with-deps chromium
+
+            export NODE_PATH="$playwright_dir/node_modules"
+            node <<'NODE'
+            const fs = require('fs');
+            const path = require('path');
+            const { chromium } = require('playwright');
+
+            const baseUrl = process.env.PREVIEW_BASE_URL;
+            const previewPages = JSON.parse(fs.readFileSync('preview-pages.json', 'utf8'));
+
+            (async () => {
+              const browser = await chromium.launch();
+
+              try {
+                for (const previewPage of previewPages) {
+                  const page = await browser.newPage({
+                    viewport: { width: 1440, height: 1200 },
+                    deviceScaleFactor: 1
+                  });
+
+                  const url = new URL(previewPage.urlPath, baseUrl).toString();
+                  const screenshotPath = path.join('preview-screenshots', `${previewPage.slug}.png`);
+
+                  console.log(`Capturing ${url} -> ${screenshotPath}`);
+                  await page.goto(url, { waitUntil: 'networkidle', timeout: 60000 });
+                  await page.screenshot({ path: screenshotPath, fullPage: true });
+                  await page.close();
+                }
+              } finally {
+                await browser.close();
+              }
+            })().catch((error) => {
+              console.error(error);
+              process.exit(1);
+            });
+            NODE
+          } > screenshot.log 2>&1 || status=$?
+
+          cat screenshot.log
+          echo "exit_code=${status}" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Upload rendered HTML previews
+        if: steps.build-site.outputs.exit_code == '0' && steps.detect-posts.outputs.count != '0'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.HTML_ARTIFACT_NAME }}
+          path: preview-html
+          if-no-files-found: ignore
+
+      - name: Upload screenshot previews
+        if: steps.build-site.outputs.exit_code == '0' && steps.detect-posts.outputs.count != '0'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.SCREENSHOT_ARTIFACT_NAME }}
+          path: preview-screenshots
+          if-no-files-found: ignore
+
+      - name: Write preview result
+        if: always() && steps.freshness.outputs.stale != 'true'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          BUILD_EXIT_CODE: ${{ steps.build-site.outputs.exit_code }}
+          HTML_EXIT_CODE: ${{ steps.html-previews.outputs.exit_code }}
+          SCREENSHOT_EXIT_CODE: ${{ steps.screenshots.outputs.exit_code }}
+          HTML_ARTIFACT_NAME: ${{ env.HTML_ARTIFACT_NAME }}
+          SCREENSHOT_ARTIFACT_NAME: ${{ env.SCREENSHOT_ARTIFACT_NAME }}
+        run: |
+          node <<'NODE'
+          const fs = require('fs');
+
+          function readLines(filePath) {
+            if (!fs.existsSync(filePath)) {
+              return [];
+            }
+
+            return fs.readFileSync(filePath, 'utf8')
+              .split(/\r?\n/)
+              .map((line) => line.trim())
+              .filter(Boolean);
+          }
+
+          function readJson(filePath, fallback) {
+            if (!fs.existsSync(filePath)) {
+              return fallback;
+            }
+
+            return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+          }
+
+          function tail(filePath, maxLines = 80, maxChars = 12000) {
+            if (!fs.existsSync(filePath)) {
+              return '';
+            }
+
+            const lines = fs.readFileSync(filePath, 'utf8').split(/\r?\n/).slice(-maxLines);
+            const content = lines.join('\n');
+            return content.length > maxChars ? content.slice(content.length - maxChars) : content;
+          }
+
+          const buildExitCode = process.env.BUILD_EXIT_CODE || '0';
+          const htmlExitCode = process.env.HTML_EXIT_CODE || '0';
+          const screenshotExitCode = process.env.SCREENSHOT_EXIT_CODE || '0';
+
+          const result = {
+            prNumber: Number(process.env.PR_NUMBER),
+            prUrl: process.env.PR_URL,
+            repository: process.env.REPOSITORY,
+            headSha: process.env.HEAD_SHA,
+            baseSha: process.env.BASE_SHA,
+            runId: process.env.RUN_ID,
+            runAttempt: process.env.RUN_ATTEMPT,
+            runUrl: `https://github.com/${process.env.REPOSITORY}/actions/runs/${process.env.RUN_ID}`,
+            htmlArtifactName: process.env.HTML_ARTIFACT_NAME,
+            screenshotArtifactName: process.env.SCREENSHOT_ARTIFACT_NAME,
+            addedPosts: readLines('added-posts.txt'),
+            previewPages: readJson('preview-pages.json', []),
+            missingPreviews: readJson('missing-previews.json', []),
+            buildExitCode,
+            htmlExitCode,
+            screenshotExitCode,
+            buildSucceeded: buildExitCode === '0',
+            htmlSucceeded: htmlExitCode === '0',
+            screenshotSucceeded: screenshotExitCode === '0',
+            buildLogTail: tail('build.log'),
+            screenshotLogTail: tail('screenshot.log')
+          };
+
+          fs.writeFileSync('preview-result.json', `${JSON.stringify(result, null, 2)}\n`);
+          NODE
+
+      - name: Upload preview result
+        if: always() && steps.freshness.outputs.stale != 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-blog-preview-result
+          path: |
+            preview-result.json
+            added-posts.txt
+            preview-pages.json
+            missing-previews.json
+            build.log
+            screenshot.log
+            static-server.log
+          if-no-files-found: ignore
+
+      - name: Fail if build or preview generation failed
+        if: always() && steps.freshness.outputs.stale != 'true'
+        env:
+          BUILD_EXIT_CODE: ${{ steps.build-site.outputs.exit_code }}
+          HTML_EXIT_CODE: ${{ steps.html-previews.outputs.exit_code }}
+          SCREENSHOT_EXIT_CODE: ${{ steps.screenshots.outputs.exit_code }}
+        run: |
+          build_exit="${BUILD_EXIT_CODE:-0}"
+          html_exit="${HTML_EXIT_CODE:-0}"
+          screenshot_exit="${SCREENSHOT_EXIT_CODE:-0}"
+
+          if [[ "$build_exit" != "0" || "$html_exit" != "0" || "$screenshot_exit" != "0" ]]; then
+            echo "Build exit code: ${build_exit}"
+            echo "HTML preview exit code: ${html_exit}"
+            echo "Screenshot preview exit code: ${screenshot_exit}"
+            exit 1
+          fi


### PR DESCRIPTION
This adds automated PR feedback for blog posts so contributors can catch Jekyll build failures before merge and reviewers can inspect generated previews for newly added posts.

## Summary

- Adds an unprivileged `pull_request` workflow that debounces commit bursts with PR-scoped concurrency, a cooldown, and stale-head detection before doing the expensive build work.
- Builds the Jekyll site, detects newly added `_posts/*.md` files, and uploads rendered HTML plus screenshot artifacts for each generated post page.
- Adds a trusted `workflow_run` commenter that updates a single PR comment with compile failures or successful preview artifact links, keeping privileged comment permissions out of the PR build job.

## Validation

- Parsed the new workflow YAML files with Ruby's YAML loader.
- Ran `git --no-pager diff --check`.
- Ran the production Jekyll build command used by the workflow: `JEKYLL_ENV=production bundle exec jekyll build -d "_site/mcscatblog" --config _config.yml`.