### PR TITLE
Fix PR preview screenshot capture

### DIFF
--- a/.github/workflows/pr-blog-preview.yml
+++ b/.github/workflows/pr-blog-preview.yml
@@ -13,7 +13,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  COOLDOWN_SECONDS: 180
   PREVIEW_BASE_URL: http://127.0.0.1:4000
   HTML_ARTIFACT_NAME: pr-blog-preview-html
   SCREENSHOT_ARTIFACT_NAME: pr-blog-preview-screenshots
@@ -25,13 +24,6 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - name: Cool down for commit bursts
-        run: |
-          if [[ "$COOLDOWN_SECONDS" =~ ^[0-9]+$ ]] && (( COOLDOWN_SECONDS > 0 )); then
-            echo "Waiting ${COOLDOWN_SECONDS}s before starting the build..."
-            sleep "$COOLDOWN_SECONDS"
-          fi
-
       - name: Check whether this run is still current
         id: freshness
         env:

--- a/.github/workflows/pr-blog-preview.yml
+++ b/.github/workflows/pr-blog-preview.yml
@@ -217,39 +217,39 @@ jobs:
 
             export NODE_PATH="$playwright_dir/node_modules"
             node <<'NODE'
-            const fs = require('fs');
-            const path = require('path');
-            const { chromium } = require('playwright');
+          const fs = require('fs');
+          const path = require('path');
+          const { chromium } = require('playwright');
 
-            const baseUrl = process.env.PREVIEW_BASE_URL;
-            const previewPages = JSON.parse(fs.readFileSync('preview-pages.json', 'utf8'));
+          const baseUrl = process.env.PREVIEW_BASE_URL;
+          const previewPages = JSON.parse(fs.readFileSync('preview-pages.json', 'utf8'));
 
-            (async () => {
-              const browser = await chromium.launch();
+          (async () => {
+            const browser = await chromium.launch();
 
-              try {
-                for (const previewPage of previewPages) {
-                  const page = await browser.newPage({
-                    viewport: { width: 1440, height: 1200 },
-                    deviceScaleFactor: 1
-                  });
+            try {
+              for (const previewPage of previewPages) {
+                const page = await browser.newPage({
+                  viewport: { width: 1440, height: 1200 },
+                  deviceScaleFactor: 1
+                });
 
-                  const url = new URL(previewPage.urlPath, baseUrl).toString();
-                  const screenshotPath = path.join('preview-screenshots', `${previewPage.slug}.png`);
+                const url = new URL(previewPage.urlPath, baseUrl).toString();
+                const screenshotPath = path.join('preview-screenshots', `${previewPage.slug}.png`);
 
-                  console.log(`Capturing ${url} -> ${screenshotPath}`);
-                  await page.goto(url, { waitUntil: 'networkidle', timeout: 60000 });
-                  await page.screenshot({ path: screenshotPath, fullPage: true });
-                  await page.close();
-                }
-              } finally {
-                await browser.close();
+                console.log(`Capturing ${url} -> ${screenshotPath}`);
+                await page.goto(url, { waitUntil: 'networkidle', timeout: 60000 });
+                await page.screenshot({ path: screenshotPath, fullPage: true });
+                await page.close();
               }
-            })().catch((error) => {
-              console.error(error);
-              process.exit(1);
-            });
-            NODE
+            } finally {
+              await browser.close();
+            }
+          })().catch((error) => {
+            console.error(error);
+            process.exit(1);
+          });
+          NODE
           } > screenshot.log 2>&1 || status=$?
 
           cat screenshot.log


### PR DESCRIPTION
The PR preview workflow currently fails before screenshot capture because the embedded Node script heredoc is indented, so Bash never sees the `NODE` terminator. This fixes that script parsing issue and removes the cooldown timer so PR checks start immediately while still keeping PR-scoped concurrency and stale-head detection.

## Summary

- Aligns the screenshot step heredoc so the embedded Node script is parsed correctly by Bash.
- Removes the 180-second cooldown step and `COOLDOWN_SECONDS` environment variable.
- Keeps `cancel-in-progress` concurrency and the latest-head SHA check to avoid stale PR runs.

## Validation

- Parsed the PR preview workflow YAML with Ruby's YAML loader.
- Extracted the screenshot step and checked it with `bash -n`.
- Ran `git --no-pager diff --check`.