### PR TITLE
Fix PR preview static server

### DIFF
--- a/.github/workflows/pr-blog-preview.yml
+++ b/.github/workflows/pr-blog-preview.yml
@@ -169,19 +169,20 @@ jobs:
         id: screenshots
         run: |
           status=0
-          server_pid=""
+          (
+            set -e
+            server_pid=""
 
-          cleanup() {
-            if [[ -n "$server_pid" ]]; then
-              kill "$server_pid" 2>/dev/null || true
-            fi
-          }
-          trap cleanup EXIT
+            cleanup() {
+              if [[ -n "$server_pid" ]]; then
+                kill "$server_pid" 2>/dev/null || true
+              fi
+            }
+            trap cleanup EXIT
 
-          {
             mkdir -p preview-screenshots
 
-            ruby -run -e httpd -- --bind-address=127.0.0.1 --port=4000 _site > static-server.log 2>&1 &
+            python3 -m http.server 4000 --bind 127.0.0.1 --directory _site > static-server.log 2>&1 &
             server_pid=$!
 
             for attempt in {1..30}; do
@@ -191,6 +192,7 @@ jobs:
 
               if (( attempt == 30 )); then
                 echo "Static preview server did not become available."
+                cat static-server.log
                 exit 1
               fi
 
@@ -242,7 +244,7 @@ jobs:
             process.exit(1);
           });
           NODE
-          } > screenshot.log 2>&1 || status=$?
+          ) > screenshot.log 2>&1 || status=$?
 
           cat screenshot.log
           echo "exit_code=${status}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
The screenshot step still failed on real post PRs because Ruby's `httpd` helper depends on the `webrick` gem, which is not installed in the action environment. This switches the temporary preview server to Python's built-in static file server and keeps the server log visible if startup fails.

## Summary

- Uses `python3 -m http.server` to serve the generated `_site` directory for screenshot capture.
- Runs the screenshot block in a subshell so startup failures are captured and printed through `screenshot.log`.
- Prints `static-server.log` when the local preview server cannot become available.

## Validation

- Parsed the PR preview workflow YAML with Ruby's YAML loader.
- Extracted the screenshot step and checked it with `bash -n`.
- Ran `git --no-pager diff --check`.