### PR TITLE
Allow PR preview comment workflow to write PR comments

### DIFF
--- a/.github/workflows/pr-blog-preview-comment.yml
+++ b/.github/workflows/pr-blog-preview-comment.yml
@@ -9,7 +9,7 @@ permissions:
   actions: read
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   comment:


### PR DESCRIPTION
The preview artifacts are being generated, but the companion `workflow_run` job fails when it tries to create the PR comment with `Resource not accessible by integration`. The run log shows the token has `Issues: write`, but GitHub's API response for PR comments also advertises `pull_requests=write`, so this grants the trusted commenter workflow that permission explicitly.

## Summary

- Changes the trusted PR preview commenter workflow from `pull-requests: read` to `pull-requests: write`.
- Keeps the build/preview workflow unprivileged; only the default-branch `workflow_run` commenter receives write access.

## Validation

- Parsed the commenter workflow YAML with Ruby's YAML loader.
- Ran `git --no-pager diff --check`.