### PR TITLE
Include assets in PR HTML previews

### DIFF
--- a/.github/workflows/pr-blog-preview.yml
+++ b/.github/workflows/pr-blog-preview.yml
@@ -102,7 +102,26 @@ jobs:
           const fs = require('fs');
           const path = require('path');
 
+          const siteBasePath = path.join('_site', 'mcscatblog');
+          const artifactBasePath = 'preview-html';
+
           fs.mkdirSync('preview-html', { recursive: true });
+          fs.writeFileSync(
+            path.join(artifactBasePath, 'README.txt'),
+            'Open the post HTML file from this folder. The assets directory is included so CSS, JavaScript, and images resolve locally.\n'
+          );
+
+          function rewriteAssetUrls(html) {
+            return html
+              .replace(/https:\/\/microsoft\.github\.io\/mcscatblog\/assets\//g, 'assets/')
+              .replace(/\/mcscatblog\/assets\//g, 'assets/')
+              .replace(/(["'(])\/assets\//g, '$1assets/');
+          }
+
+          const siteAssetsPath = path.join(siteBasePath, 'assets');
+          if (fs.existsSync(siteAssetsPath)) {
+            fs.cpSync(siteAssetsPath, path.join(artifactBasePath, 'assets'), { recursive: true });
+          }
 
           const posts = fs.readFileSync('added-posts.txt', 'utf8')
             .split(/\r?\n/)
@@ -125,8 +144,8 @@ jobs:
             }
 
             const slug = match[1];
-            const htmlPath = path.join('_site', 'mcscatblog', 'posts', slug, 'index.html');
-            const htmlArtifactPath = path.join('preview-html', `${slug}.html`);
+            const htmlPath = path.join(siteBasePath, 'posts', slug, 'index.html');
+            const htmlArtifactPath = path.join(artifactBasePath, `${slug}.html`);
 
             if (!fs.existsSync(htmlPath)) {
               missingPreviews.push({
@@ -137,7 +156,8 @@ jobs:
               continue;
             }
 
-            fs.copyFileSync(htmlPath, htmlArtifactPath);
+            const html = fs.readFileSync(htmlPath, 'utf8');
+            fs.writeFileSync(htmlArtifactPath, rewriteAssetUrls(html));
             previewPages.push({
               post,
               slug,


### PR DESCRIPTION
The screenshot preview renders correctly because it is captured from the full built site, but the downloadable HTML artifact only contained the post HTML file. Opening that file locally left CSS, JavaScript, and post images unresolved.

## Summary

- Copies the generated `assets` directory into the `pr-blog-preview-html` artifact.
- Rewrites generated asset URLs in each copied post HTML file from site-root paths to local `assets/...` paths.
- Adds a short README to the artifact explaining how to open the local preview.

## Validation

- Parsed the workflow YAML with Ruby's YAML loader.
- Ran a local Jekyll production build.
- Executed the extracted HTML preview preparation step against a generated post preview and confirmed the artifact contains `assets/css/jekyll-theme-chirpy.css` and rewritten local asset paths.
- Ran `git --no-pager diff --check`.