### PR TITLE
Limit PR HTML preview artifact assets

### DIFF
--- a/.github/workflows/pr-blog-preview.yml
+++ b/.github/workflows/pr-blog-preview.yml
@@ -104,11 +104,12 @@ jobs:
 
           const siteBasePath = path.join('_site', 'mcscatblog');
           const artifactBasePath = 'preview-html';
+          const assetUrls = new Set();
 
           fs.mkdirSync('preview-html', { recursive: true });
           fs.writeFileSync(
             path.join(artifactBasePath, 'README.txt'),
-            'Open the post HTML file from this folder. The assets directory is included so CSS, JavaScript, and images resolve locally.\n'
+            'Open the post HTML file from this folder. Only assets referenced by the generated preview HTML are included.\n'
           );
 
           function rewriteAssetUrls(html) {
@@ -118,9 +119,30 @@ jobs:
               .replace(/(["'(])\/assets\//g, '$1assets/');
           }
 
-          const siteAssetsPath = path.join(siteBasePath, 'assets');
-          if (fs.existsSync(siteAssetsPath)) {
-            fs.cpSync(siteAssetsPath, path.join(artifactBasePath, 'assets'), { recursive: true });
+          function collectAssetUrls(html) {
+            for (const match of html.matchAll(/assets\/[^"')\s<>]+/g)) {
+              assetUrls.add(match[0].replace(/[?#].*$/, ''));
+            }
+          }
+
+          function copyReferencedAssets() {
+            for (const assetUrl of assetUrls) {
+              const normalizedAssetPath = path.normalize(assetUrl);
+              const assetPrefix = `assets${path.sep}`;
+
+              if (!normalizedAssetPath.startsWith(assetPrefix)) {
+                continue;
+              }
+
+              const sourcePath = path.join(siteBasePath, normalizedAssetPath);
+              if (!fs.existsSync(sourcePath) || !fs.statSync(sourcePath).isFile()) {
+                continue;
+              }
+
+              const targetPath = path.join(artifactBasePath, normalizedAssetPath);
+              fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+              fs.copyFileSync(sourcePath, targetPath);
+            }
           }
 
           const posts = fs.readFileSync('added-posts.txt', 'utf8')
@@ -157,7 +179,9 @@ jobs:
             }
 
             const html = fs.readFileSync(htmlPath, 'utf8');
-            fs.writeFileSync(htmlArtifactPath, rewriteAssetUrls(html));
+            const rewrittenHtml = rewriteAssetUrls(html);
+            collectAssetUrls(rewrittenHtml);
+            fs.writeFileSync(htmlArtifactPath, rewrittenHtml);
             previewPages.push({
               post,
               slug,
@@ -166,6 +190,8 @@ jobs:
               urlPath: `/mcscatblog/posts/${slug}/`
             });
           }
+
+          copyReferencedAssets();
 
           fs.writeFileSync('preview-pages.json', `${JSON.stringify(previewPages, null, 2)}\n`);
           fs.writeFileSync('missing-previews.json', `${JSON.stringify(missingPreviews, null, 2)}\n`);


### PR DESCRIPTION
The previous HTML preview fix copied the full generated `assets` directory into the artifact so local HTML would have CSS and images. That made the artifact far too large because `assets/posts` contains media for every blog post.

## Summary

- Keeps rewriting generated asset URLs to local `assets/...` paths.
- Copies only the asset files actually referenced by the generated preview HTML.
- Leaves the artifact self-contained for the previewed post without bundling unrelated post media.

## Validation

- Parsed the workflow YAML with Ruby's YAML loader.
- Ran a local Jekyll production build.
- Ran the extracted HTML preview preparation step against an existing post with a large asset folder; the local preview artifact was about 7.5 MB instead of copying the full site media tree.
- Ran `git --no-pager diff --check`.