### PR TITLE
Add Classic/Modern agent edition pill to posts

### DIFF
--- a/.github/workflows/pr-blog-preview.yml
+++ b/.github/workflows/pr-blog-preview.yml
@@ -48,6 +48,36 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Validate agent_edition front matter
+        if: steps.freshness.outputs.stale != 'true'
+        run: |
+          # Mirrors _plugins/validate-agent-edition.rb so contributors get a
+          # fast, clear failure on the PR before the full Jekyll build runs.
+          # Every post must declare: agent_edition: classic | modern | both
+          allowed_regex='^agent_edition:[[:space:]]*(classic|modern|both)[[:space:]]*$'
+          offenders=()
+
+          for post in _posts/*.md; do
+            [ -e "$post" ] || continue
+            value_line="$(grep -m1 -E '^agent_edition:' "$post" || true)"
+
+            if [[ -z "$value_line" ]]; then
+              offenders+=("  - ${post}: missing \`agent_edition\`")
+            elif ! grep -qiE "$allowed_regex" <<<"$value_line"; then
+              offenders+=("  - ${post}: invalid \`${value_line}\`")
+            fi
+          done
+
+          if (( ${#offenders[@]} > 0 )); then
+            echo "::error::Every post must set 'agent_edition' to one of: classic | modern | both"
+            printf '%s\n' "${offenders[@]}"
+            echo ""
+            echo "Add 'agent_edition: classic' (or 'modern' / 'both') to the front matter of each post listed above."
+            exit 1
+          fi
+
+          echo "All posts declare a valid agent_edition."
+
       - name: Setup Ruby
         if: steps.freshness.outputs.stale != 'true'
         uses: ruby/setup-ruby@v1

--- a/README.md
+++ b/README.md
@@ -47,6 +47,45 @@ How to contribute:
 
 Learn about writing new posts in Chirpy: [Writing a New Post](https://chirpy.cotes.page/posts/write-a-new-post/)
 
+## Theme customizations (read before upgrading Chirpy)
+
+This site is built on the **upstream `jekyll-theme-chirpy` gem** (see `Gemfile`). The
+items below are **local additions on top of the theme**. They are not part of Chirpy and
+will **not** receive upstream updates automatically.
+
+> ⚠️ **Use at your own peril.** These customizations are maintained by us, not by the
+> Chirpy project. When bumping the `jekyll-theme-chirpy` version in the `Gemfile`, review
+> each item below against the new gem version. Anything that overrides or copies a theme
+> file is the most likely thing to break.
+
+### Classic / Modern agent edition pill
+
+Shows a small pill under the post title indicating whether a post is about a **Classic**
+or **Modern** Copilot Studio agent. **Every post must set this field — the build fails
+otherwise** (enforced by `_plugins/validate-agent-edition.rb`). Set it in front matter:
+
+```yaml
+agent_edition: classic   # one of: classic | modern | both
+```
+
+- `classic` — applies to classic agents
+- `modern` — applies to modern (rebuilt) agents
+- `both` — applies to both; renders a neutral "Classic & Modern" pill
+
+| File | What it is | Upgrade risk |
+| ---- | ---------- | ------------ |
+| `_layouts/post.html` | **Full copy** of the gem's `post.html` with a pill block added in `<header>` (look for the `LOCAL OVERRIDE` comment). | **High.** This is a frozen copy. If Chirpy changes its own `post.html` (new meta, TOC, image handling, etc.), those changes are silently lost. On each upgrade, diff our copy against `$(bundle show jekyll-theme-chirpy)/_layouts/post.html` and re-apply the pill block onto the new version. |
+| `assets/css/jekyll-theme-chirpy.scss` | `.agent-edition-pill` styles appended at the end. | **Low.** Self-contained classes appended after the theme import; unlikely to collide. Verify the `@use 'main...'` import line at the top still matches the gem. |
+| `_plugins/validate-agent-edition.rb` | Build-time validator that fails the build if any post is missing a valid `agent_edition`. | **Low.** Plugin-only; runs because `pages-deploy.yml` builds with our own Jekyll (not GitHub Pages safe mode). If you ever switch to safe mode, custom plugins won't run and this check is silently skipped. |
+
+To re-sync the layout after an upgrade:
+
+```shell
+diff _layouts/post.html "$(bundle show jekyll-theme-chirpy)/_layouts/post.html"
+```
+
+Re-apply the `LOCAL OVERRIDE` block to the new layout, then rebuild.
+
 ## Chirpy Theme Info
 
 [![Gem Version](https://img.shields.io/gem/v/jekyll-theme-chirpy)][gem]&nbsp;

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,200 @@
+---
+layout: default
+refactor: true
+panel_includes:
+  - toc
+tail_includes:
+  - related-posts
+  - post-nav
+script_includes:
+  - comment
+---
+
+{% include lang.html %}
+
+{% include toc-status.html %}
+
+<article class="px-1" data-toc="{{ enable_toc }}">
+  <header>
+    <h1 data-toc-skip>{{ page.title }}</h1>
+
+    <!-- LOCAL OVERRIDE: Classic/Modern Copilot Studio edition pill.
+         See README "Theme customizations" before upgrading jekyll-theme-chirpy. -->
+    {% if page.agent_edition %}
+      {% assign _edition = page.agent_edition | downcase | strip %}
+      <p class="agent-edition mb-3" data-toc-skip>
+        <span class="agent-edition-pill agent-edition--{{ _edition }}">
+          {% if _edition == 'classic' %}
+            <i class="fa-regular fa-clock fa-fw"></i>Classic agents
+          {% elsif _edition == 'modern' %}
+            <i class="fa-solid fa-wand-magic-sparkles fa-fw"></i>Modern agents
+          {% elsif _edition == 'both' %}
+            <i class="fa-solid fa-layer-group fa-fw"></i>Modern &amp; Classic agents
+          {% else %}
+            <i class="fa-solid fa-tag fa-fw"></i>{{ page.agent_edition }}
+          {% endif %}
+        </span>
+      </p>
+    {% endif %}
+    <!-- END LOCAL OVERRIDE -->
+
+    {% if page.description %}
+      <p class="post-desc fw-light mb-4">{{ page.description }}</p>
+    {% endif %}
+
+    <div class="post-meta text-muted">
+      <!-- published date -->
+      <span>
+        {{ site.data.locales[lang].post.posted }}
+        {% include datetime.html date=page.date tooltip=true lang=lang %}
+      </span>
+
+      <!-- lastmod date -->
+      {% if page.last_modified_at and page.last_modified_at != page.date %}
+        <span>
+          {{ site.data.locales[lang].post.updated }}
+          {% include datetime.html date=page.last_modified_at tooltip=true lang=lang %}
+        </span>
+      {% endif %}
+
+      {% if page.image %}
+        {% capture src %}src="{{ page.image.path | default: page.image }}"{% endcapture %}
+        {% capture class %}class="preview-img{% if page.image.no_bg %}{{ ' no-bg' }}{% endif %}"{% endcapture %}
+        {% capture alt %}alt="{{ page.image.alt | xml_escape | default: "Preview Image" }}"{% endcapture %}
+
+        {% if page.image.lqip %}
+          {%- capture lqip -%}lqip="{{ page.image.lqip }}"{%- endcapture -%}
+        {% endif %}
+
+        <div class="mt-3 mb-3">
+          <img {{ src }} {{ class }} {{ alt }} w="1200" h="630" {{ lqip }}>
+          {%- if page.image.alt -%}
+            <figcaption class="text-center pt-2 pb-2">{{ page.image.alt }}</figcaption>
+          {%- endif -%}
+        </div>
+      {% endif %}
+
+      <div class="d-flex justify-content-between">
+        <!-- author(s) -->
+        <span>
+          {% if page.author %}
+            {% assign authors = page.author %}
+          {% elsif page.authors %}
+            {% assign authors = page.authors %}
+          {% endif %}
+
+          {{ site.data.locales[lang].post.written_by }}
+
+          <em>
+            {% if authors %}
+              {% for author in authors %}
+                {% if site.data.authors[author].url -%}
+                  <a href="{{ site.data.authors[author].url }}">{{ site.data.authors[author].name }}</a>
+                {%- else -%}
+                  {{ site.data.authors[author].name }}
+                {%- endif %}
+                {% unless forloop.last %}{{ '</em>, <em>' }}{% endunless %}
+              {% endfor %}
+            {% else %}
+              <a href="{{ site.social.links[0] }}">{{ site.social.name }}</a>
+            {% endif %}
+          </em>
+        </span>
+
+        <div>
+          <!-- pageviews -->
+          {% if site.pageviews.provider and site.analytics[site.pageviews.provider].id %}
+            <span>
+              <em id="pageviews">
+                <i class="fas fa-spinner fa-spin small"></i>
+              </em>
+              {{ site.data.locales[lang].post.pageview_measure }}
+            </span>
+          {% endif %}
+
+          <!-- read time -->
+          {% include read-time.html content=content prompt=true lang=lang %}
+        </div>
+      </div>
+    </div>
+  </header>
+
+  {% if enable_toc %}
+    <div id="toc-bar" class="d-flex align-items-center justify-content-between invisible">
+      <span class="label text-truncate">{{ page.title }}</span>
+      <button type="button" class="toc-trigger btn me-1">
+        <i class="fa-solid fa-list-ul fa-fw"></i>
+      </button>
+    </div>
+
+    <button id="toc-solo-trigger" type="button" class="toc-trigger btn btn-outline-secondary btn-sm">
+      <span class="label ps-2 pe-1">{{- site.data.locales[lang].panel.toc -}}</span>
+      <i class="fa-solid fa-angle-right fa-fw"></i>
+    </button>
+
+    <dialog id="toc-popup" class="p-0">
+      <div class="header d-flex flex-row align-items-center justify-content-between">
+        <div class="label text-truncate py-2 ms-4">{{- page.title -}}</div>
+        <button id="toc-popup-close" type="button" class="btn mx-1 my-1 opacity-75">
+          <i class="fas fa-close"></i>
+        </button>
+      </div>
+      <div id="toc-popup-content" class="px-4 py-3 pb-4"></div>
+    </dialog>
+  {% endif %}
+
+  <div class="content">
+    {{ content }}
+  </div>
+
+  <div class="post-tail-wrapper text-muted">
+    <!-- categories -->
+    {% if page.categories.size > 0 %}
+      <div class="post-meta mb-3">
+        <i class="far fa-folder-open fa-fw me-1"></i>
+        {% for category in page.categories %}
+          <a href="{{ site.baseurl }}/categories/{{ category | slugify | url_encode }}/">{{ category }}</a>
+          {%- unless forloop.last -%},{%- endunless -%}
+        {% endfor %}
+      </div>
+    {% endif %}
+
+    <!-- tags -->
+    {% if page.tags.size > 0 %}
+      <div class="post-tags">
+        <i class="fa fa-tags fa-fw me-1"></i>
+        {% for tag in page.tags %}
+          <a
+            href="{{ site.baseurl }}/tags/{{ tag | slugify | url_encode }}/"
+            class="post-tag no-text-decoration"
+          >
+            {{- tag -}}
+          </a>
+        {% endfor %}
+      </div>
+    {% endif %}
+
+    <div
+      class="
+        post-tail-bottom
+        d-flex justify-content-between align-items-center mt-5 pb-2
+      "
+    >
+      <div class="license-wrapper">
+        {% if site.data.locales[lang].copyright.license.template %}
+          {% capture _replacement %}
+        <a href="{{ site.data.locales[lang].copyright.license.link }}">
+          {{ site.data.locales[lang].copyright.license.name }}
+        </a>
+        {% endcapture %}
+
+          {{ site.data.locales[lang].copyright.license.template | replace: ':LICENSE_NAME', _replacement }}
+        {% endif %}
+      </div>
+
+      {% include post-sharing.html lang=lang %}
+    </div>
+    <!-- .post-tail-bottom -->
+  </div>
+  <!-- div.post-tail-wrapper -->
+</article>

--- a/_plugins/validate-agent-edition.rb
+++ b/_plugins/validate-agent-edition.rb
@@ -1,0 +1,39 @@
+#!/usr/bin/env ruby
+#
+# LOCAL CUSTOMIZATION (not part of the Chirpy theme).
+# Fails the build if any published post is missing a valid `agent_edition`
+# front-matter value. This keeps the Classic vs. Modern Copilot Studio agent
+# distinction explicit on every post (it drives the edition pill rendered in
+# _layouts/post.html). See README "Theme customizations".
+
+ALLOWED_AGENT_EDITIONS = %w[classic modern both].freeze
+
+Jekyll::Hooks.register :site, :post_read do |site|
+  offenders = []
+
+  site.posts.docs.each do |post|
+    value = post.data['agent_edition']
+    normalized = value.to_s.downcase.strip
+
+    next if ALLOWED_AGENT_EDITIONS.include?(normalized)
+
+    # Path relative to the site source, for a readable error message.
+    rel_path = post.path.sub(/\A#{Regexp.escape(site.source)}\/?/, '')
+
+    offenders << if value.nil? || normalized.empty?
+                   "  - #{rel_path}: missing `agent_edition`"
+                 else
+                   "  - #{rel_path}: invalid `agent_edition: #{value}`"
+                 end
+  end
+
+  next if offenders.empty?
+
+  message = +"Build failed: every post must set `agent_edition` to one of " \
+             "#{ALLOWED_AGENT_EDITIONS.join(' or ')}.\n"
+  message << offenders.join("\n")
+  message << "\n\nAdd `agent_edition: classic` (or `modern`) to the front matter " \
+             "of each post listed above."
+
+  raise message
+end

--- a/_posts/2025-09-20-copilot-studio-child-connected-agents-inputs-outputs.md
+++ b/_posts/2025-09-20-copilot-studio-child-connected-agents-inputs-outputs.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "Using Inputs and Outputs in Child and Connected Agents"
 date: 2025-09-20

--- a/_posts/2025-09-21-connector-consent-card-obo.md
+++ b/_posts/2025-09-21-connector-consent-card-obo.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "Intercepting and Responding to Connector Consent Cards via the Agents SDK"
 date: 2025-09-21

--- a/_posts/2025-09-24-copilot-studio-custom-knowledge-source.md
+++ b/_posts/2025-09-24-copilot-studio-custom-knowledge-source.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "Connecting to Custom Knowledge Sources in Copilot Studio"
 date: 2025-09-24

--- a/_posts/2025-09-25-triggering-copilot-studio-http.md
+++ b/_posts/2025-09-25-triggering-copilot-studio-http.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "Triggering Copilot Studio Agents with HTTP Calls"
 date: 2025-09-25

--- a/_posts/2025-10-15-copilot-studio-passing-files-flows-connectors.md
+++ b/_posts/2025-10-15-copilot-studio-passing-files-flows-connectors.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "Tutorial: Passing Files from Copilot Studio to Agent Flows, Connectors and Tools"
 date: 2025-10-15

--- a/_posts/2025-10-22-mcp-custom-headers.md
+++ b/_posts/2025-10-22-mcp-custom-headers.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "Adding Custom Headers to MCP Connectors in Copilot Studio"
 date: 2025-10-22

--- a/_posts/2025-10-29-mcp-tools-resources.md
+++ b/_posts/2025-10-29-mcp-tools-resources.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "Using MCP Resources in Copilot Studio"
 date: 2025-10-29

--- a/_posts/2025-11-05-show-reasoning-agents-sdk.md
+++ b/_posts/2025-11-05-show-reasoning-agents-sdk.md
@@ -1,4 +1,5 @@
 ---  
+agent_edition: classic
 layout: post  
 title: "Showing Agent Reasoning in Custom UIs (Anthropic + Agents SDK)"  
 date: 2025-11-04 22:00:00 +0100  

--- a/_posts/2025-11-11-copilot-studio-teams-deployment-ux.md
+++ b/_posts/2025-11-11-copilot-studio-teams-deployment-ux.md
@@ -1,4 +1,5 @@
 ---  
+agent_edition: classic
 layout: post
 title: "Best Practices for Deploying Copilot Studio Agents in Microsoft Teams"
 date: 2025-11-14 17:30:00 +0100

--- a/_posts/2025-11-11-influence-orchestration-knowledge.md
+++ b/_posts/2025-11-11-influence-orchestration-knowledge.md
@@ -1,4 +1,5 @@
 ---  
+agent_edition: classic
 layout: post
 title: "Influencing Agent Planning with Contextual Instructions"
 date: 2025-11-11 11:11:00 +0100

--- a/_posts/2025-11-11-mcs-http-connector-sso.md
+++ b/_posts/2025-11-11-mcs-http-connector-sso.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "(Nearly) Seamless Sign-In for Custom APIs in Copilot Studio"
 date: 2025-11-11

--- a/_posts/2025-11-14-unlocking-seamless-access-how-to-ensure-users-can-create-connections-for-copilot-studio-agents.md
+++ b/_posts/2025-11-14-unlocking-seamless-access-how-to-ensure-users-can-create-connections-for-copilot-studio-agents.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "Unlocking Seamless Access: How to Ensure Users Can Create Connections for Copilot Studio Agents"
 date: 2025-11-21

--- a/_posts/2025-11-15-custom-connector-sso.md
+++ b/_posts/2025-11-15-custom-connector-sso.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "Enabling SSO for Custom Connectors in Copilot Studio"
 date: 2025-11-15

--- a/_posts/2025-11-18-you-dont-need-manual-auth.md
+++ b/_posts/2025-11-18-you-dont-need-manual-auth.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "You Probably Don't Need Manual Authentication (And Didn't Even Know It)"
 date: 2025-11-18

--- a/_posts/2025-11-19-a365-mcp-servers-copilot-studio.md
+++ b/_posts/2025-11-19-a365-mcp-servers-copilot-studio.md
@@ -1,4 +1,5 @@
 ---  
+agent_edition: classic
 layout: post  
 title: "Bringing Microsoft 365 Copilot into Copilot Studio with Agent 365 MCP Servers"  
 date: 2025-11-19 09:00:00 +0100  

--- a/_posts/2025-11-25-mcp-resources-as-tool-inputs.md
+++ b/_posts/2025-11-25-mcp-resources-as-tool-inputs.md
@@ -1,4 +1,5 @@
 ---    
+agent_edition: classic
 layout: post    
 title: "Free Up Your Context Window: Pass MCP Resources, Not Raw Data"    
 date: 2025-11-24 23:50:00 +0100    

--- a/_posts/2025-11-27-copilot-studio-handover-live-agent.md
+++ b/_posts/2025-11-27-copilot-studio-handover-live-agent.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "Handing Over to Live Agents Without Losing Control"
 date: 2025-12-14

--- a/_posts/2025-12-02-copilot-studio-a2a-multi-agents.md
+++ b/_posts/2025-12-02-copilot-studio-a2a-multi-agents.md
@@ -1,4 +1,5 @@
 ---  
+agent_edition: classic
 layout: post  
 title: "Quickstart: Connect an A2A Agent to Copilot Studio"  
 date: 2025-12-02 14:00:00 +0100  

--- a/_posts/2025-12-05-obo-for-custom-connectors.md
+++ b/_posts/2025-12-05-obo-for-custom-connectors.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "Seamless SSO with Custom Connectors (Yes It's Possible!)"
 date: 2025-12-05

--- a/_posts/2025-12-05-subscribe-rss-feed.md
+++ b/_posts/2025-12-05-subscribe-rss-feed.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "How to Subscribe to the Custom Engine Blog via RSS"
 date: 2025-12-05

--- a/_posts/2025-12-10-custom-api-and-mcp-in-declarative-agents.md
+++ b/_posts/2025-12-10-custom-api-and-mcp-in-declarative-agents.md
@@ -1,4 +1,5 @@
 ---      
+agent_edition: classic
 layout: post      
 title: "VIDEO TUTORIAL: Add Custom APIs and MCP Servers to Declarative Agents"      
 date: 2025-12-10 9:00:00 +0100      

--- a/_posts/2025-12-13-A2A-Dad-jokes-Building-Python-Agents-with-Microsoft-365-SDK-for-MCS.md
+++ b/_posts/2025-12-13-A2A-Dad-jokes-Building-Python-Agents-with-Microsoft-365-SDK-for-MCS.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "From Dad Jokes to A2A: Building Python Agents That Talk to Copilot Studio"
 date: 2025-12-13

--- a/_posts/2025-12-15-connecting-snfl-to-mcs.md
+++ b/_posts/2025-12-15-connecting-snfl-to-mcs.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "Connecting Snowflake to Copilot Studio: Step-by-Step Guide"
 date: 2025-12-15 17:30:00 +0100

--- a/_posts/2025-12-15-remove-citations-in-copilot-studio-answer.md
+++ b/_posts/2025-12-15-remove-citations-in-copilot-studio-answer.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "Kill the [1]: How to Remove Citations from Copilot Studio Answers"
 date: 2025-12-15

--- a/_posts/2025-12-16-connect-foundry-agents-in-copilotstudio.md
+++ b/_posts/2025-12-16-connect-foundry-agents-in-copilotstudio.md
@@ -1,4 +1,5 @@
 ---  
+agent_edition: classic
 layout: post  
 title: "Video Demo: Connect a Microsoft Foundry agent in Copilot Studio"  
 date: 2025-12-16 14:32:00 +0100  

--- a/_posts/2026-01-02-adaptive-card-generation.md
+++ b/_posts/2026-01-02-adaptive-card-generation.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "{Brace Yourself} - or Let Copilot Do It! Zero-100 with Adaptive Cards"
 date: 2026-01-02

--- a/_posts/2026-01-08-localize-adaptive-cards.md
+++ b/_posts/2026-01-08-localize-adaptive-cards.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "The One Card: Build Once, Speak All Languages"
 date: 2026-01-08

--- a/_posts/2026-01-09-cua-cloudpcpool-in-copilotstudio.md
+++ b/_posts/2026-01-09-cua-cloudpcpool-in-copilotstudio.md
@@ -1,4 +1,5 @@
 ---  
+agent_edition: classic
 layout: post  
 title: "Video Demo: Implement Cloud PC Pool for Computer Use in Microsoft Copilot Studio"  
 date: 2026-01-09 16:44:00 +0100  

--- a/_posts/2026-01-10-search-enabled.md
+++ b/_posts/2026-01-10-search-enabled.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "Search Enabled: Powering The Custom Engine Blog with Algolia"
 date: 2026-01-10 00:00:00 +0100

--- a/_posts/2026-01-11-mocked-webchat-welcome-message.md
+++ b/_posts/2026-01-11-mocked-webchat-welcome-message.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "The Welcome Message That Never Was: Mocking Agent Greetings in WebChat"
 date: 2026-01-11

--- a/_posts/2026-01-16-response-analysis-copilot-tool.md
+++ b/_posts/2026-01-16-response-analysis-copilot-tool.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "Agentic Tooling: Making Agent Performance Transparent and Measurable"
 date: 2026-01-16

--- a/_posts/2026-01-23-copilot-studio-defeating-oversummarization.md
+++ b/_posts/2026-01-23-copilot-studio-defeating-oversummarization.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "Defeating Oversummarization in AI Agents: How to Deliver Exact Content from Knowledge Sources"
 date: 2026-01-23 12:00:00 +0100

--- a/_posts/2026-01-24-conversationid-users.md
+++ b/_posts/2026-01-24-conversationid-users.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "How to Get Your Conversation ID When Chatting with Agents"
 date: 2026-01-24 00:00:00 +0000

--- a/_posts/2026-01-26-meeting-transcript-analyzer.md
+++ b/_posts/2026-01-26-meeting-transcript-analyzer.md
@@ -1,4 +1,5 @@
 ---      
+agent_edition: classic
 layout: post      
 title: "VIDEO: Retrieve Meeting Transcripts in Copilot Studio & Block Focus Time"      
 date: 2026-01-26 9:00:00 +0100      

--- a/_posts/2026-01-26-webchat-embed-zero-javascript.md
+++ b/_posts/2026-01-26-webchat-embed-zero-javascript.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "Embedding WebChat Without Writing a Single Line of JavaScript"
 date: 2026-01-26

--- a/_posts/2026-01-29-compare-mcp-servers-pp-connectors.md
+++ b/_posts/2026-01-29-compare-mcp-servers-pp-connectors.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: both
 layout: post
 title: "MCP Servers or Connectors in Copilot Studio? A Maker's Guide"
 date: 2026-02-13 12:00:00 +0100

--- a/_posts/2026-02-02-webchat-middlewares.md
+++ b/_posts/2026-02-02-webchat-middlewares.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "VIDEO: Mastering WebChat Middleware for Copilot Studio Agents"
 date: 2026-02-02 9:00:00 +0100

--- a/_posts/2026-02-11-dynamic-knowledge-urls-copilot-studio.md
+++ b/_posts/2026-02-11-dynamic-knowledge-urls-copilot-studio.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "Zero Noise, Maximum Relevance: Dynamic Knowledge URLs in Copilot Studio"
 date: 2026-02-11 00:00:00 +0000

--- a/_posts/2026-02-20-webchat-conversation-history-m365-sdk.md
+++ b/_posts/2026-02-20-webchat-conversation-history-m365-sdk.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "The Conversation History Gap in the M365 Agents SDK (And How We Filled It)"
 date: 2026-02-20

--- a/_posts/2026-02-24-servicenow-copilot-studio-widget.md
+++ b/_posts/2026-02-24-servicenow-copilot-studio-widget.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "Embedding Copilot Studio Directly in ServiceNow (And Why Auth Was the Easy Part)"
 date: 2026-02-24

--- a/_posts/2026-03-02-copilot-studio-api-decision-guide.md
+++ b/_posts/2026-03-02-copilot-studio-api-decision-guide.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "Every Path to Integrating Your Copilot Studio Agent"
 date: 2026-03-02

--- a/_posts/2026-03-03-connecting-copilot-studio-dataverse-mcp-endpoint-across-environments.md
+++ b/_posts/2026-03-03-connecting-copilot-studio-dataverse-mcp-endpoint-across-environments.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "Connecting Copilot Studio to a Dataverse MCP Endpoint Across Environments: A Practical Guide"
 date: 2026-03-03 00:00:00 +0000

--- a/_posts/2026-03-06-copilot-studio-kit.md
+++ b/_posts/2026-03-06-copilot-studio-kit.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "Copilot Studio Kit: Beyond Test Automation"
 date: 2026-03-06

--- a/_posts/2026-03-10-skills-for-copilot-studio.md
+++ b/_posts/2026-03-10-skills-for-copilot-studio.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "Skills for Copilot Studio: Build agents from YAML code, up to 20x Faster"
 date: 2026-03-10 9:00:00 +0100

--- a/_posts/2026-03-13-power-of-topics-copilot-studio.md
+++ b/_posts/2026-03-13-power-of-topics-copilot-studio.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "The Orchestrator’s Secrets: Chain-of-Thought & Transcript on Demand"
 date: 2026-03-17 00:00:00 +0000

--- a/_posts/2026-03-13-salesforce-copilot-studio-handoff.md
+++ b/_posts/2026-03-13-salesforce-copilot-studio-handoff.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "Salesforce Handoff to Copilot Studio: From Bare Docs to One-Click Deploy"
 date: 2026-03-13

--- a/_posts/2026-03-19-open-the-hood-copilot-studio-transcripts.md
+++ b/_posts/2026-03-19-open-the-hood-copilot-studio-transcripts.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "Open the Hood: What Your Copilot Studio Agent Is Really Doing"
 description: "How to extract, read, and understand Copilot Studio conversation transcripts so you know what your agent is doing and why."

--- a/_posts/2026-03-19-open-the-hood-technical-reference.md
+++ b/_posts/2026-03-19-open-the-hood-technical-reference.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "Open the Hood: Technical Reference for Copilot Studio Transcripts"
 description: "Data model deep-dive, Dataverse vs Application Insights comparison, and all six transcript access methods with code examples."

--- a/_posts/2026-03-20-dataverse-search-in-copilot-studio-unauthenticated-structured-data.md
+++ b/_posts/2026-03-20-dataverse-search-in-copilot-studio-unauthenticated-structured-data.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 title: "Structured Data with Zero User Auth: Dataverse searchQuery in Copilot Studio"
 date: 2026-03-20
 categories: [copilot-studio, dataverse]

--- a/_posts/2026-03-26-claude-copilot-skills-copilot-studio-plugin-demo.md
+++ b/_posts/2026-03-26-claude-copilot-skills-copilot-studio-plugin-demo.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "Live Demo: Using the Claude Code Plugin to Author a Copilot Studio Agent"
 date: 2026-03-26 9:00:00 +0100

--- a/_posts/2026-03-27-dynamic-mcp-routing-copilot-studio.md
+++ b/_posts/2026-03-27-dynamic-mcp-routing-copilot-studio.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "Dynamic MCP Routing in Copilot Studio: One Connector, Many Endpoints"
 date: 2026-03-27

--- a/_posts/2026-03-29-agentic-improvement-loop.md
+++ b/_posts/2026-03-29-agentic-improvement-loop.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "Closing the Loop: Automated Agent Improvement with Publish and Test"
 date: 2026-03-29

--- a/_posts/2026-04-01-connecting-legacy-desktop-apps-to-copilot-studio.md
+++ b/_posts/2026-04-01-connecting-legacy-desktop-apps-to-copilot-studio.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "Bridging the Gap: Connecting Legacy Desktop Applications to Copilot Studio Agents"
 date: 2026-04-15

--- a/_posts/2026-04-07-copilot-studio-teams-agent-patterns.md
+++ b/_posts/2026-04-07-copilot-studio-teams-agent-patterns.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "Design Copilot Studio Agents for Teams (Because Test Chat Was Too Easy)"
 date: 2026-04-07

--- a/_posts/2026-04-07-copilot-studio-teams-deployment.md
+++ b/_posts/2026-04-07-copilot-studio-teams-deployment.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "From DEV to PROD: Deploying Copilot Studio Agents to Teams and Microsoft 365 Copilot"
 date: 2026-04-07

--- a/_posts/2026-04-10-dataverse-retrieval-patterns-copilot-studio.md
+++ b/_posts/2026-04-10-dataverse-retrieval-patterns-copilot-studio.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "Dataverse Retrieval Patterns for Structured Data in Copilot Studio Agents"
 date: 2026-04-10

--- a/_posts/2026-04-10-hello-world-mcp-copilot-studio.md
+++ b/_posts/2026-04-10-hello-world-mcp-copilot-studio.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "Five Minutes to Your First MCP Connector in Copilot Studio"
 date: 2026-04-10

--- a/_posts/2026-04-17-combining-agent-flows-and-agents-gotchas-errors-and-patterns.md
+++ b/_posts/2026-04-17-combining-agent-flows-and-agents-gotchas-errors-and-patterns.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "Combining Agent Flows with Agents: Gotchas, Errors, and Patterns"
 date: 2026-04-17

--- a/_posts/2026-04-17-embed-copilot-studio-agents-canvas-apps.md
+++ b/_posts/2026-04-17-embed-copilot-studio-agents-canvas-apps.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "Embed Copilot Studio Agents in Canvas Apps with a PCF Control"
 date: 2026-04-17

--- a/_posts/2026-04-17-no-copilot-license-m365-channel.md
+++ b/_posts/2026-04-17-no-copilot-license-m365-channel.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "No, You Don't Need a Copilot License to Deploy Agents to Microsoft 365 Copilot"
 date: 2026-04-17

--- a/_posts/2026-04-19-copilot-studio-eval-gate-azure-devops.md
+++ b/_posts/2026-04-19-copilot-studio-eval-gate-azure-devops.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "Quality Gates for Copilot Studio: Automated Evaluations in Azure DevOps"
 date: 2026-04-19

--- a/_posts/2026-04-28-webchat-context-variables.md
+++ b/_posts/2026-04-28-webchat-context-variables.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "How to Set Context Variables to Copilot Studio Agents Using WebChat"
 date: 2026-04-28 9:00:00 +0100

--- a/_posts/2026-04-30-tool-inputs-sharepoint-list.md
+++ b/_posts/2026-04-30-tool-inputs-sharepoint-list.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "Get Answers Over SharePoint Lists and Other Structured Data — Turning Natural Language into Dynamic Queries in Copilot Studio"
 date: 2026-04-30

--- a/_posts/2026-05-07-managing-azure-consumption-power-platform.md
+++ b/_posts/2026-05-07-managing-azure-consumption-power-platform.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: both
 layout: post
 title: "Real-Time PAYG Overage Protection with Power Automate, Custom Connectors"
 date: 2026-05-07

--- a/_posts/2026-05-12-bulk-file-testing-copilot-evals.md
+++ b/_posts/2026-05-12-bulk-file-testing-copilot-evals.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "Bulk File-Based Testing for Copilot Studio: Beyond Standard Evals"
 date: 2026-05-12

--- a/_posts/2026-05-13-managing-spend-pay-as-you-go.md
+++ b/_posts/2026-05-13-managing-spend-pay-as-you-go.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: both
 layout: post
 title: "Herding Clouds: Taming Pay-As-You-Go Billing Policies in Power Platform at Scale"
 date: 2026-05-13

--- a/_posts/2026-05-15-atlassian-jira-remote-mcp-copilot-studio.md
+++ b/_posts/2026-05-15-atlassian-jira-remote-mcp-copilot-studio.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "Wiring up the Jira (Atlassian) Remote MCP server in Copilot Studio in 5 mins"
 date: 2026-05-15

--- a/_posts/2026-05-19-pdf-page-level-citations.md
+++ b/_posts/2026-05-19-pdf-page-level-citations.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "Page-Level PDF Citations in Copilot Studio"
 date: 2026-06-02

--- a/_posts/2026-05-20-alm-copilot-studio-agents-foundation.md
+++ b/_posts/2026-05-20-alm-copilot-studio-agents-foundation.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "ALM for Copilot Studio Agents: The Foundation"
 date: 2026-06-03

--- a/_posts/2026-05-20-human-in-the-loop-custom-connector.md
+++ b/_posts/2026-05-20-human-in-the-loop-custom-connector.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "Building a Custom Human-in-the-Loop Experience for Copilot Studio Workflows"
 date: 2026-05-20

--- a/_posts/2026-05-22-snowflake-mcp-copilot-studio.md
+++ b/_posts/2026-05-22-snowflake-mcp-copilot-studio.md
@@ -1,4 +1,5 @@
 ---
+agent_edition: classic
 layout: post
 title: "Wiring up a Snowflake-managed MCP server in Copilot Studio"
 date: 2026-05-22

--- a/assets/css/jekyll-theme-chirpy.scss
+++ b/assets/css/jekyll-theme-chirpy.scss
@@ -1061,3 +1061,99 @@ html[data-mode="dark"] {
     }
   }
 }
+
+/* =========================================================================
+   Classic / Modern Copilot Studio "edition" pill
+   Rendered by the LOCAL override in _layouts/post.html (driven by the
+   `agent_edition` front-matter field). Subtle, but clearly visible under
+   the post title. See README "Theme customizations".
+   ========================================================================= */
+
+.agent-edition {
+  /* keeps the pill on its own line, tight under the title */
+  line-height: 1;
+}
+
+.agent-edition-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4em;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  padding: 0.22em 0.7em;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  white-space: nowrap;
+  vertical-align: middle;
+
+  i {
+    font-size: 0.85em;
+  }
+}
+
+/* Classic: warm, archival amber */
+.agent-edition--classic {
+  color: #8a6d1f;
+  background-color: rgba(255, 193, 7, 0.12);
+  border-color: rgba(255, 193, 7, 0.40);
+}
+
+/* Modern: the site's blue→purple brand accent */
+.agent-edition--modern {
+  color: #6a2bd6;
+  background-color: rgba(127, 57, 251, 0.10);
+  border-color: rgba(127, 57, 251, 0.35);
+}
+
+/* Both: bright teal, distinct from classic amber and modern purple */
+.agent-edition--both {
+  color: #0e8a86;
+  background-color: rgba(20, 184, 166, 0.12);
+  border-color: rgba(20, 184, 166, 0.45);
+}
+
+/* Dark mode (Chirpy toggle) */
+html[data-mode="dark"] {
+  .agent-edition--classic {
+    color: #f0c14b;
+    background-color: rgba(255, 193, 7, 0.14);
+    border-color: rgba(255, 193, 7, 0.35);
+  }
+
+  .agent-edition--modern {
+    color: #c4a4ff;
+    background-color: rgba(127, 57, 251, 0.18);
+    border-color: rgba(127, 57, 251, 0.45);
+  }
+
+  .agent-edition--both {
+    color: #5eead4;
+    background-color: rgba(20, 184, 166, 0.18);
+    border-color: rgba(20, 184, 166, 0.50);
+  }
+}
+
+/* Dark mode via system preference (when no explicit toggle) */
+@media (prefers-color-scheme: dark) {
+  html:not([data-mode="light"]) {
+    .agent-edition--classic {
+      color: #f0c14b;
+      background-color: rgba(255, 193, 7, 0.14);
+      border-color: rgba(255, 193, 7, 0.35);
+    }
+
+    .agent-edition--modern {
+      color: #c4a4ff;
+      background-color: rgba(127, 57, 251, 0.18);
+      border-color: rgba(127, 57, 251, 0.45);
+    }
+
+    .agent-edition--both {
+      color: #5eead4;
+      background-color: rgba(20, 184, 166, 0.18);
+      border-color: rgba(20, 184, 166, 0.50);
+    }
+  }
+}


### PR DESCRIPTION
## What

Adds an `agent_edition` front-matter field so every post visibly signals whether it relates to **Classic** or **Modern** Copilot Studio agents (relevant as Copilot Studio is being rebuilt). A subtle, color-coded pill renders under the post title.

| Value | Pill | Color |
| --- | --- | --- |
| `classic` | Classic agents | amber |
| `modern` | Modern agents | purple |
| `both` | Modern & Classic agents | teal |

## Changes

- **`_layouts/post.html`** — local override of the Chirpy post layout adding the pill block.
- **`assets/css/jekyll-theme-chirpy.scss`** — pill styles with light/dark variants.
- **`_plugins/validate-agent-edition.rb`** — **fails the build** if any post is missing a valid `agent_edition`.
- **`.github/workflows/pr-blog-preview.yml`** — fast, early PR check mirroring the plugin so contributors get a clear failure before deploy.
- **Backfill** — all existing posts set to `classic`, except the connectors-vs-MCP guide and the two PAYG/billing posts (`both`).
- **README** — new "Theme customizations" section documenting each item and its **theme-upgrade risk** (the layout override is a frozen copy; re-diff against the gem on every Chirpy bump).

## Notes

⚠️ `_layouts/post.html` is a full copy of the gem layout. When bumping `jekyll-theme-chirpy`, diff our copy against the new gem version and re-apply the `LOCAL OVERRIDE` block.