### PR TITLE
Pin the new orchestrator resources post

### DIFF
--- a/_posts/2026-07-07-new-orchestrator-resources.md
+++ b/_posts/2026-07-07-new-orchestrator-resources.md
@@ -6,6 +6,7 @@ date: 2026-07-07
 categories: [copilot-studio, orchestration]
 tags: [copilot-studio, modern-agents, orchestration, migration, skills, agent-development]
 mermaid: false
+pin: true
 description: "The new Copilot Studio experience is a big shift. We shipped three resources so you can understand it, see it run, and migrate to it. Here's how to use each one."
 author: [giorgioughini, roels, adilei, henryjammes, chrisgarty, lewisdoesdev, adrianatruji]
 image:


### PR DESCRIPTION
Adds `pin: true` to the front matter of the "New Orchestrator, New Rules? CAT's Got You" post so the resource guide stays pinned to the top of the home list.

This is Chirpy's built-in mechanism for pinning a post; no other changes.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>