### PR TITLE
Add canonical Copilot Studio harness naming to review skill

### DIFF
--- a/.claude/skills/mcscatblog-review-post/SKILL.md
+++ b/.claude/skills/mcscatblog-review-post/SKILL.md
@@ -61,6 +61,33 @@ Before checking anything technical, read the post top to bottom as a reader woul
 - Callouts use Chirpy prompt boxes, not emoji
 - Tags maximize Chirpy "Further Reading" overlap with existing posts
 
+### Naming and Terminology (canonical)
+
+Copilot Studio is **one product**. It offers three *harnesses* (build experiences), not three separate products. Flag any framing that treats a harness as its own product. Prose should lead with "Copilot Studio" and introduce a harness name only when precision requires it.
+
+Flag and correct non-canonical harness names to these canonical ones:
+
+| Canonical harness | What it is | Reject these terms |
+| --- | --- | --- |
+| **Copilot Chat harness** | Customize Microsoft 365 Copilot with your organization's knowledge. | "Chat agent", "DA", "classic/old Copilot Studio" |
+| **Standard harness** | Rule-based conversational agents with predefined topics and flows. | "Basic orchestration", "Advanced", "Samba", "classic/old Copilot Studio" |
+| **GitHub Copilot harness** | Optimize your business processes with an agentic build experience. | "New Copilot Studio", "Dracarys" |
+
+Additional checks:
+
+- Harnesses are build choices, not separate products.
+- Use the term "harness" consistently; avoid alternates such as "orchestrator".
+- Avoid scale labels such as Basic, Advanced, Premium, or Ultimate; they don't scale as new harnesses are added.
+- Context note (keep any cost/licensing phrasing factual and brief): as of 8/3, Copilot Studio supports building agents with a new GitHub Copilot harness (GA); agents built with it are billed on a usage basis and are not eligible for inclusion in Microsoft 365 Copilot licensing.
+
+**Front-matter `agent_edition` taxonomy** (established by PR #352, "Retire classic/modern edition naming"). This field drives the under-title pill rendered in `_layouts/post.html` and validated by `_plugins/validate-agent-edition.rb`. Canonical values and what they render:
+
+- `standard` → "Standard harness" pill
+- `github-copilot` → "GHCP harness" pill
+- `both` → "Both harnesses" pill
+
+Deprecated aliases `classic` → `standard` and `modern` → `github-copilot` are still accepted but should be migrated. Review check: every post sets a valid `agent_edition`, and posts using `classic`/`modern` should be updated to the canonical value.
+
 ### Output the Review
 
 - List the **top 5-7 issues** ranked by impact.
@@ -77,6 +104,7 @@ After presenting the review, ask the user which fixes to apply. Common fixes inc
 - Cutting tangential sections
 - Making YAML blocks collapsible
 - Grammar, spelling, terminology corrections
+- Correcting Copilot Studio product/harness terminology to canonical names (see Naming and Terminology)
 - Front matter corrections (dates, tags, categories)
 - Image resizing (use Python PIL)
 - Replacing emoji callouts with Chirpy prompt boxes


### PR DESCRIPTION
Teaches the `mcscatblog-review-post` skill to check posts against the canonical Copilot Studio / harness naming and the `agent_edition` front-matter taxonomy.

## What changed
Edits only `.claude/skills/mcscatblog-review-post/SKILL.md`:

- New `### Naming and Terminology (canonical)` subsection under **Step 3: Review the Post** (after *Front Matter and Images*). It captures that Copilot Studio is **one product** with three *harnesses* (build experiences), the canonical names and one-liners for each — **Copilot Chat harness**, **Standard harness**, **GitHub Copilot harness** — the non-canonical terms to reject (e.g. "Dracarys", "Samba", "DA", "New/old Copilot Studio"), guidance to avoid scale labels (Basic/Advanced/Premium/Ultimate) and the term "orchestrator", and a brief factual note on the GitHub Copilot harness GA / usage-based billing.
- Documents the front-matter `agent_edition` taxonomy from #352 ("Retire classic/modern edition naming"): `standard` → "Standard harness", `github-copilot` → "GHCP harness", `both` → "Both harnesses", with deprecated aliases `classic` → `standard` and `modern` → `github-copilot` to be migrated. Values verified against `_layouts/post.html` and `_plugins/validate-agent-edition.rb`.
- One new bullet in **Step 4: Apply Fixes** for correcting product/harness terminology to canonical names.

No posts, assets, or other files are touched — this is standalone skill guidance.