### PR TITLE
Redesign home page with curated topics and uniform cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MCS CAT Blog
 
 ## What is the purpose of this blog?
-The Microsoft Copilot Studio (MCS) Customer Advisory Team (CAT) Blog is intended to be a **technical** notebook for sharing quick, practical patterns and snippets that are useful in customer scenarios but don’t fit into formal documentation or guidance. 
+The Microsoft Copilot Acceleration Team (CAT) Blog for Copilot Studio (MCS) is intended to be a **technical** notebook for sharing quick, practical patterns and snippets that are useful in customer scenarios but don’t fit into formal documentation or guidance. 
 The public site is https://microsoft.github.io/mcscatblog/.
 
 More specifically, this blog is meant to be:

--- a/_config.yml
+++ b/_config.yml
@@ -127,7 +127,7 @@ pwa:
     deny_paths:
       # - "/example"  # URLs match `<SITE_URL>/example/*` will not be cached by the PWA
 
-paginate: 10
+paginate: 12
 
 # The base URL of your site
 baseurl: "/mcscatblog"

--- a/_config.yml
+++ b/_config.yml
@@ -17,7 +17,7 @@ timezone:
 title: The Custom Engine
 tagline: Technical examples and best practices from the Microsoft Copilot Studio CAT team
 description: >-
-  Technical examples from the Microsoft Copilot Studio Customer Advisory Team.
+  Technical examples from the Microsoft Copilot Acceleration Team.
 
 # Fill in the protocol & hostname for your site.
 # E.g. 'https://username.github.io', note that it does not end with a '/'.

--- a/_data/collections.yml
+++ b/_data/collections.yml
@@ -1,0 +1,52 @@
+# Display metadata for the "Collections" grid on the home page.
+#
+# The grid itself is GENERATED from the site's real post categories
+# (see _includes/home-collections.html) — this file only supplies the
+# title, icon, colour and blurb for each category slug. Any category
+# without an entry here still renders with a sensible fallback, so the
+# home page stays in sync with whatever categories posts actually use.
+orchestration:
+  title: Orchestration
+  icon: fa-diagram-project
+  color: "#9F63FF"
+  blurb: "Generative orchestration, multi-agent routing, and topic design."
+mcp:
+  title: "MCP & Tools"
+  icon: fa-plug
+  color: "#58B2FF"
+  blurb: "Model Context Protocol servers, tools, skills, and resources."
+authentication:
+  title: "Authentication & Identity"
+  icon: fa-shield-halved
+  color: "#FF6794"
+  blurb: "SSO, on-behalf-of, Entra ID, and consent flows."
+channels:
+  title: Channels
+  icon: fa-comments
+  color: "#35C2B1"
+  blurb: "WebChat, embedding, and Microsoft Teams."
+knowledge:
+  title: "Knowledge & Retrieval"
+  icon: fa-book-open
+  color: "#FFB347"
+  blurb: "Knowledge sources, retrieval, search, and structured-data patterns."
+automation:
+  title: "Automation & Integration"
+  icon: fa-network-wired
+  color: "#FF6FCF"
+  blurb: "Custom connectors, agent flows, RPA, and line-of-business integration."
+agents-sdk:
+  title: "Agents SDK"
+  icon: fa-code
+  color: "#7C8CFF"
+  blurb: "Pro-code custom engine agents with the M365 Agents SDK."
+alm:
+  title: "Governance & ALM"
+  icon: fa-scale-balanced
+  color: "#4FC66E"
+  blurb: "Lifecycle, governance, licensing, and shipping to production."
+testing:
+  title: "Testing & Evaluation"
+  icon: fa-flask
+  color: "#FF8A5B"
+  blurb: "Evals, batch testing, and scoring answer quality."

--- a/_includes/home-collections.html
+++ b/_includes/home-collections.html
@@ -1,0 +1,66 @@
+{% comment %}
+  Collections — the navigability signature of the home page.
+
+  Generated from the site's real post CATEGORIES: every category becomes a
+  tile with a live post count linking to its archive, ordered by how much
+  content it holds (richest topics first). Presentation (title, icon, colour,
+  blurb) comes from _data/collections.yml keyed by the category slug; unmapped
+  categories fall back to a sensible default. Utility categories in `skip`
+  never appear.
+{% endcomment %}
+
+{% assign skip = "blog" | split: "," %}
+
+<section class="ce-collections" id="collections" aria-label="Browse by topic">
+  <header class="ce-section-head">
+    <p class="ce-kicker">// Browse by topic</p>
+    <h2 class="ce-section-title">Topics</h2>
+    <a class="ce-section-link" href="{{ '/categories/' | relative_url }}">
+      All topics <i class="fas fa-angle-right"></i>
+    </a>
+  </header>
+
+  <div class="ce-grid">
+    {% comment %} Sort by live post count, desc. Counts are offset by 1000 so a
+       plain lexical sort orders them numerically, then reversed for desc. {% endcomment %}
+    {% assign rows = "" %}
+    {% for pair in site.categories %}
+      {% unless skip contains pair[0] %}
+        {% assign n = pair[1] | size | plus: 1000 %}
+        {% assign rows = rows | append: n | append: '#' | append: pair[0] | append: '|' %}
+      {% endunless %}
+    {% endfor %}
+    {% assign ordered = rows | split: '|' | sort | reverse %}
+
+    {% for row in ordered %}
+      {% unless row == blank %}
+        {% assign parts = row | split: '#' %}
+        {% assign count = parts[0] | minus: 1000 %}
+        {% assign name = parts[1] %}
+        {% assign meta = site.data.collections[name] %}
+        {% if meta %}
+          {% assign title = meta.title %}
+          {% assign icon = meta.icon %}
+          {% assign color = meta.color %}
+          {% assign blurb = meta.blurb %}
+        {% else %}
+          {% assign title = name | replace: '-', ' ' | capitalize %}
+          {% assign icon = 'fa-folder-open' %}
+          {% assign color = 'var(--ce-accent)' %}
+          {% assign blurb = '' %}
+        {% endif %}
+
+        <a class="ce-tile" href="{{ name | slugify | prepend: '/categories/' | append: '/' | relative_url }}" style="--tile-color: {{ color }};">
+          <div class="ce-tile__top">
+            <span class="ce-tile__icon"><i class="fas {{ icon }}"></i></span>
+          </div>
+          <h3 class="ce-tile__title">{{ title }}</h3>
+          {% if blurb != '' %}<p class="ce-tile__blurb">{{ blurb }}</p>{% endif %}
+          <span class="ce-tile__count">
+            {{ count }} {% if count == 1 %}post{% else %}posts{% endif %}
+          </span>
+        </a>
+      {% endunless %}
+    {% endfor %}
+  </div>
+</section>

--- a/_includes/home-featured.html
+++ b/_includes/home-featured.html
@@ -1,0 +1,25 @@
+{% comment %}
+  Featured posts — a curated band directly under the masthead. Surfaces posts
+  flagged with `pin: true` in front matter, using the exact same card as the
+  Latest feed for a single, consistent visual language. Rendered only when at
+  least one post is featured, and only on the first paginator page. These posts
+  are excluded from the Latest feed (see home.html) to avoid duplication.
+{% endcomment %}
+
+{% assign featured = site.posts | where: 'pin', 'true' %}
+
+{% if featured.size > 0 %}
+  <section class="ce-featured" id="featured" aria-label="Featured posts">
+    <header class="ce-section-head">
+      <p class="ce-kicker">// Featured</p>
+      {% comment %} Curated headline describing the current pinned set; update when the pins change. {% endcomment %}
+      <h2 class="ce-section-title">Building inside the GHCP harness</h2>
+    </header>
+
+    <div class="ce-feed">
+      {% for post in featured %}
+        {% include home-post-card.html post=post %}
+      {% endfor %}
+    </div>
+  </section>
+{% endif %}

--- a/_includes/home-hero.html
+++ b/_includes/home-hero.html
@@ -20,8 +20,8 @@
     </h1>
 
     <p class="ce-hero__lede">
-      Deep technical dives, patterns, and hard-won gotchas from Microsoft's Copilot Studio
-      Customer Advisory Team, helping the builders and architects who ship.
+      Deep technical dives, patterns, and hard-won gotchas from Microsoft's
+      Copilot Acceleration Team, helping the builders and architects who ship agents.
     </p>
 
     <div class="ce-hero__actions">

--- a/_includes/home-hero.html
+++ b/_includes/home-hero.html
@@ -1,0 +1,44 @@
+{% comment %}
+  Home masthead. Renders the publication identity + thesis and a small,
+  live catalog stat line. Shown only on the first paginator page.
+{% endcomment %}
+
+{% assign post_total = site.posts | size %}
+{% comment %} Count live topic collections = distinct post categories, minus utility ones. {% endcomment %}
+{% assign skip = "blog" | split: "," %}
+{% assign topic_total = 0 %}
+{% for pair in site.categories %}
+  {% unless skip contains pair[0] %}{% assign topic_total = topic_total | plus: 1 %}{% endunless %}
+{% endfor %}
+
+<section class="ce-hero" aria-label="Introduction">
+  <div class="ce-hero__main">
+    <p class="ce-kicker">// The Custom Engine · Copilot Studio CAT</p>
+
+    <h1 class="ce-hero__title">
+      Field notes for building <span class="ce-hero__accent">real</span> Copilot&nbsp;Studio agents.
+    </h1>
+
+    <p class="ce-hero__lede">
+      Deep technical dives, patterns, and hard-won gotchas from Microsoft's Copilot Studio
+      Customer Advisory Team, helping the builders and architects who ship.
+    </p>
+
+    <div class="ce-hero__actions">
+      <a href="#collections" class="ce-btn ce-btn--primary">
+        <i class="fas fa-compass"></i> Browse by topic
+      </a>
+      <a href="#latest" class="ce-btn ce-btn--ghost">
+        <i class="fas fa-arrow-down-short-wide"></i> Latest posts
+      </a>
+    </div>
+
+    <p class="ce-hero__stats">
+      <span>{{ post_total }} deep dives</span>
+      <span class="ce-dot">·</span>
+      <span>{{ topic_total }} topics</span>
+      <span class="ce-dot">·</span>
+      <span>Updated weekly</span>
+    </p>
+  </div>
+</section>

--- a/_includes/home-post-card.html
+++ b/_includes/home-post-card.html
@@ -1,0 +1,67 @@
+{% comment %}
+  Uniform post card, shared by the Featured band and the Latest feed so both
+  use exactly the same visual language. Pass a post:
+
+    {% include home-post-card.html post=post %}
+
+  Renders a 16:9 thumbnail (post image, or a branded placeholder when the post
+  has none), a category eyebrow, title, excerpt, and date.
+{% endcomment %}
+
+{% assign post = include.post %}
+
+<article class="ce-card">
+  <a href="{{ post.url | relative_url }}" class="ce-card__link">
+    {% comment %} ---- Uniform 16:9 thumbnail (image or branded placeholder) ---- {% endcomment %}
+    {% if post.image %}
+      {% assign src = post.image.path | default: post.image %}
+      {% if post.media_subpath %}
+        {% unless src contains '://' %}
+          {% assign src = post.media_subpath | append: '/' | append: src | replace: '///', '/' | replace: '//', '/' %}
+        {% endunless %}
+      {% endif %}
+
+      {% assign lqip_attr = '' %}
+      {% if post.image.lqip %}
+        {% assign lqip = post.image.lqip %}
+        {% if post.media_subpath %}
+          {% unless lqip contains 'data:' %}
+            {% assign lqip = post.media_subpath | append: '/' | append: lqip | replace: '///', '/' | replace: '//', '/' %}
+          {% endunless %}
+        {% endif %}
+        {% assign lqip_attr = 'lqip="' | append: lqip | append: '"' %}
+      {% endif %}
+
+      {% assign alt = post.image.alt | xml_escape | default: 'Preview image' %}
+
+      <div class="ce-thumb">
+        <img src="{{ src }}" alt="{{ alt }}" loading="lazy" {{ lqip_attr }}>
+      </div>
+    {% else %}
+      {% assign ph_label = post.categories[1] | default: post.categories[0] | default: 'Copilot Studio' %}
+      <div class="ce-thumb ce-thumb--placeholder">
+        <span class="ce-thumb__chip"><i class="fas fa-microchip"></i></span>
+        <span class="ce-thumb__label">{{ ph_label }}</span>
+      </div>
+    {% endif %}
+
+    <div class="ce-card__body">
+      {% if post.categories.size > 0 %}
+        <div class="ce-card__top">
+          <p class="ce-card__eyebrow">{{ post.categories | join: ' · ' }}</p>
+        </div>
+      {% endif %}
+
+      <h3 class="ce-card__title">{{ post.title }}</h3>
+
+      <p class="ce-card__excerpt">{% include post-summary.html %}</p>
+
+      <div class="ce-card__meta">
+        <span class="ce-card__date">
+          <i class="far fa-calendar"></i>
+          {% include datetime.html date=post.date lang=lang %}
+        </span>
+      </div>
+    </div>
+  </a>
+</article>

--- a/_includes/metadata-hook.html
+++ b/_includes/metadata-hook.html
@@ -1,1 +1,9 @@
 <meta name="algolia-site-verification"  content="46C247BC7C8677B2" />
+
+<!-- Custom fonts for the home redesign: display (Space Grotesk) + mono labels (JetBrains Mono) -->
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link
+  href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@500;600&display=swap"
+  rel="stylesheet"
+>

--- a/_includes/post-paginator.html
+++ b/_includes/post-paginator.html
@@ -1,0 +1,105 @@
+<!--
+  Local override of Chirpy's post-paginator.
+
+  The home feed (see _layouts/home.html) excludes pinned posts, so it can be
+  shorter than site.posts. jekyll-paginate's `paginator.total_pages` counts ALL
+  posts and would emit an empty trailing page reachable via the "next" arrow.
+  We drive the pager off `feed_total_pages` (set in home.html, in scope here)
+  so the widget stops at the last page that actually has feed posts.
+-->
+
+{% assign total = feed_total_pages | default: paginator.total_pages %}
+{% assign next = paginator.page | plus: 1 %}
+{% assign prev = paginator.page | minus: 1 %}
+
+<nav aria-label="Page Navigation">
+  <ul class="pagination align-items-center mt-4 mb-0">
+    <!-- left arrow -->
+    {% if paginator.page > 1 %}
+      {% if prev == 1 %}
+        {% assign prev_url = '/' | relative_url %}
+      {% else %}
+        {% assign prev_url = site.paginate_path | replace: ':num', prev | relative_url %}
+      {% endif %}
+    {% else %}
+      {% assign prev_url = '#' %}
+    {% endif %}
+
+    <li class="page-item {% if paginator.page <= 1 %}disabled{% endif %}">
+      <a class="page-link" href="{{ prev_url }}" aria-label="previous-page">
+        <i class="fas fa-angle-left"></i>
+      </a>
+    </li>
+
+    <!-- page numbers -->
+    {% assign left_ellipsis = false %}
+    {% assign right_ellipsis = false %}
+
+    {% for i in (1..total) %}
+      {% assign pre = paginator.page | minus: 1 %}
+      {% assign pre_less = pre | minus: 1 %}
+      {% assign show = false %}
+
+      {% if paginator.page == 1 %}
+        {% if i <= 3 or i == total %}
+          {% assign show = true %}
+        {% endif %}
+      {% elsif paginator.page == total %}
+        {% if i == 1 or i >= pre_less %}
+          {% assign show = true %}
+        {% endif %}
+      {% else %}
+        {% if i == 1 or i == total %}
+          {% assign show = true %}
+        {% elsif i >= pre and i <= next %}
+          {% assign show = true %}
+        {% endif %}
+      {% endif %}
+
+      {% if show %}
+        <!-- show number -->
+        <li class="page-item {% if i == paginator.page %} active{% endif %}">
+          <a
+            class="page-link"
+            href="{% if i > 1 %}{{ site.paginate_path | replace: ':num', i | relative_url }}{% else %}{{ '/' | relative_url }}{% endif %}"
+          >
+            {{- i -}}
+          </a>
+        </li>
+      {% else %}
+        <!-- hide number -->
+        {% if i < pre and left_ellipsis == false %}
+          <li class="page-item disabled">
+            <span class="page-link">...</span>
+          </li>
+          {% assign left_ellipsis = true %}
+        {% elsif i > next and right_ellipsis == false %}
+          <li class="page-item disabled">
+            <span class="page-link">...</span>
+          </li>
+          {% assign right_ellipsis = true %}
+        {% endif %}
+      {% endif %}
+    {% endfor %}
+
+    <!-- mobile pagination -->
+    <li class="page-index align-middle">
+      <span>{{ paginator.page }}</span>
+      <span class="text-muted">/ {{ total }}</span>
+    </li>
+
+    <!-- right arrow -->
+    {% if paginator.page < total %}
+      {% assign next_url = site.paginate_path | replace: ':num', next | relative_url %}
+    {% else %}
+      {% assign next_url = '#' %}
+    {% endif %}
+
+    <li class="page-item {% if paginator.page >= total %}disabled{% endif %}">
+      <a class="page-link" href="{{ next_url }}" aria-label="next-page">
+        <i class="fas fa-angle-right"></i>
+      </a>
+    </li>
+  </ul>
+</nav>
+<!-- .pagination -->

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,104 @@
+---
+layout: compress
+---
+
+<!doctype html>
+
+{% include origin-type.html %}
+
+{% include lang.html %}
+
+<!-- `site.alt_lang` can specify a language different from the UI -->
+<html
+  lang="{{ page.lang | default: site.alt_lang | default: site.lang }}"
+  {%- if site.theme_mode == 'light' or site.theme_mode == 'dark' -%}
+    data-bs-theme="{{ site.theme_mode }}"
+  {%- endif -%}
+>
+  {% include head.html lang=lang %}
+
+  <body{% if page.layout == 'home' %} class="home"{% endif %}>
+    {% include sidebar.html lang=lang %}
+
+    <div id="main-wrapper" class="d-flex justify-content-center">
+      <div class="container d-flex flex-column px-xxl-5">
+        {% include topbar.html lang=lang %}
+
+        <!-- NOTE (home redesign): on the home page the main column spans full
+             width and the right panel is dropped, because the Collections grid
+             and Latest feed replace Recently-Updated / Trending-Tags. All other
+             pages keep the original two-column layout. -->
+        {% assign is_home = false %}
+        {% if page.layout == 'home' %}
+          {% assign is_home = true %}
+        {% endif %}
+
+        <div class="row flex-grow-1">
+          <main
+            aria-label="Main Content"
+            class="{% if is_home %}col-12{% else %}col-12 col-lg-11 col-xl-9{% endif %} px-md-4"
+          >
+            {% if layout.layout == 'default' %}
+              {% include refactor-content.html content=content lang=lang %}
+            {% else %}
+              {{ content }}
+            {% endif %}
+          </main>
+
+          {% unless is_home %}
+            <!-- panel -->
+            <aside aria-label="Panel" id="panel-wrapper" class="col-xl-3 ps-2 text-muted">
+              <div class="access">
+                {% include_cached update-list.html lang=lang %}
+                {% include_cached trending-tags.html lang=lang %}
+              </div>
+
+              {% for _include in layout.panel_includes %}
+                {% assign _include_path = _include | append: '.html' %}
+                {% include {{ _include_path }} lang=lang %}
+              {% endfor %}
+            </aside>
+          {% endunless %}
+        </div>
+
+        <div class="row">
+          <!-- tail -->
+          <div
+            id="tail-wrapper"
+            class="{% if is_home %}col-12{% else %}col-12 col-lg-11 col-xl-9{% endif %} px-md-4"
+          >
+            {% for _include in layout.tail_includes %}
+              {% assign _include_path = _include | append: '.html' %}
+              {% include {{ _include_path }} lang=lang %}
+            {% endfor %}
+
+            {% include_cached footer.html lang=lang %}
+          </div>
+        </div>
+
+        {% include_cached search-results.html lang=lang %}
+      </div>
+
+      <aside aria-label="Scroll to Top">
+        <button id="back-to-top" type="button" class="btn btn-lg btn-box-shadow">
+          <i class="fas fa-angle-up"></i>
+        </button>
+      </aside>
+    </div>
+
+    <div id="mask" class="d-none position-fixed w-100 h-100 z-1"></div>
+
+    {% if site.pwa.enabled %}
+      {% include_cached notification.html lang=lang %}
+    {% endif %}
+
+    <!-- Embedded scripts -->
+
+    {% for _include in layout.script_includes %}
+      {% assign _include_path = _include | append: '.html' %}
+      {% include {{ _include_path }} %}
+    {% endfor %}
+
+    {% include_cached search-loader.html lang=lang %}
+  </body>
+</html>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,0 +1,61 @@
+---
+layout: default
+---
+
+{% include lang.html %}
+
+{% comment %}
+  Featured (pinned) posts get their own band on page 1 (home-featured.html);
+  the Latest feed below is the chronological stream of everything else, with
+  pinned and hidden posts excluded to avoid duplication, windowed by the current
+  paginator page. When nothing is pinned there is no Featured band and every
+  post simply flows through the feed.
+
+  The feed excludes pinned posts, so it can be shorter than site.posts. We derive
+  feed_total_pages from the feed itself and drive the pager off that; gating on
+  jekyll-paginate's paginator.total_pages would emit an empty trailing page
+  reachable via the "next" arrow.
+{% endcomment %}
+{% assign feed_posts = site.posts | where_exp: 'item', 'item.pin != true and item.hidden != true' %}
+{% assign feed_total_pages = feed_posts.size | plus: paginator.per_page | minus: 1 | divided_by: paginator.per_page %}
+
+{% assign feed_start = paginator.page | minus: 1 | times: paginator.per_page %}
+{% assign feed_end = feed_start | plus: paginator.per_page | minus: 1 %}
+
+{% assign posts = '' | split: '' %}
+{% for i in (feed_start..feed_end) %}
+  {% if feed_posts[i] %}
+    {% assign posts = posts | push: feed_posts[i] %}
+  {% endif %}
+{% endfor %}
+
+{% comment %} Hero + featured + collections only lead the very first page. {% endcomment %}
+{% if paginator.page == 1 %}
+  {% include home-hero.html %}
+  {% include home-featured.html %}
+  {% include home-collections.html %}
+{% endif %}
+
+<section class="ce-latest" id="latest" aria-label="Latest posts">
+  <header class="ce-section-head">
+    <p class="ce-kicker">// {% if paginator.page == 1 %}Fresh off the bench{% else %}Page {{ paginator.page }}{% endif %}</p>
+    <h2 class="ce-section-title">Latest</h2>
+    <a class="ce-section-link" href="{{ '/archives/' | relative_url }}">
+      All posts <i class="fas fa-angle-right"></i>
+    </a>
+  </header>
+
+  {% if posts.size > 0 %}
+  <div id="post-list" class="ce-feed">
+    {% for post in posts %}
+      {% include home-post-card.html post=post %}
+    {% endfor %}
+  </div>
+  {% else %}
+  <p class="ce-feed-empty">You've reached the end. <a href="{{ '/archives/' | relative_url }}">Browse the full archive</a> or <a href="{{ '/' | relative_url }}">head back to the top</a>.</p>
+  {% endif %}
+</section>
+
+{% if feed_total_pages > 1 %}
+  {% include post-paginator.html %}
+{% endif %}

--- a/_posts/2025-09-20-copilot-studio-child-connected-agents-inputs-outputs.md
+++ b/_posts/2025-09-20-copilot-studio-child-connected-agents-inputs-outputs.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "Using Inputs and Outputs in Child and Connected Agents"
 date: 2025-09-20
-categories: [copilot-studio, tutorial, multi-agent]
+categories: [orchestration]
 tags: [child-agents, connected-agents, orchestration, inputs, outputs]
 author: adilei
 ---

--- a/_posts/2025-09-21-connector-consent-card-obo.md
+++ b/_posts/2025-09-21-connector-consent-card-obo.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "Intercepting and Responding to Connector Consent Cards via the Agents SDK"
 date: 2025-09-21
-categories: [copilot-studio, connectors, authentication]
+categories: [authentication]
 tags: [obo, consent, connectors, agents-sdk, adaptive-cards]
 description: Detect a connector consent (OBO) Adaptive Card, summarize it, and submit Allow or Cancel.
 #image: /assets/posts/connector-consent-card-obo/consent.png

--- a/_posts/2025-09-24-copilot-studio-custom-knowledge-source.md
+++ b/_posts/2025-09-24-copilot-studio-custom-knowledge-source.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "Connecting to Custom Knowledge Sources in Copilot Studio"
 date: 2025-09-24
-categories: [copilot-studio, tutorial, knowledge]
+categories: [knowledge]
 tags: [custom-knowledge, search, orchestration, generative-answers]
 author: adilei
 ---

--- a/_posts/2025-09-25-triggering-copilot-studio-http.md
+++ b/_posts/2025-09-25-triggering-copilot-studio-http.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "Triggering Copilot Studio Agents with HTTP Calls"
 date: 2025-09-25
-categories: [copilot-studio, tutorial, api]
+categories: [automation]
 tags: [http, direct-line, power-automate, api-integration]
 author: roels
 ---

--- a/_posts/2025-10-15-copilot-studio-passing-files-flows-connectors.md
+++ b/_posts/2025-10-15-copilot-studio-passing-files-flows-connectors.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "Tutorial: Passing Files from Copilot Studio to Agent Flows, Connectors and Tools"
 date: 2025-10-15
-categories: [copilot-studio, tutorial, integration]
+categories: [automation]
 tags: [agent-flows, power-automate, connectors, tools, file-handling]
 author: raemone
 ---

--- a/_posts/2025-10-22-mcp-custom-headers.md
+++ b/_posts/2025-10-22-mcp-custom-headers.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "Adding Custom Headers to MCP Connectors in Copilot Studio"
 date: 2025-10-22
-categories: [copilot-studio, tutorial, mcp]
+categories: [mcp]
 tags: [mcp, model-context-protocol, custom-connector, headers, authentication]
 author: adilei
 ---

--- a/_posts/2025-10-29-mcp-tools-resources.md
+++ b/_posts/2025-10-29-mcp-tools-resources.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "Using MCP Resources in Copilot Studio"
 date: 2025-10-29
-categories: [copilot-studio, mcp, agents]
+categories: [mcp]
 tags: [model-context-protocol, resources, tools, search, enterprise-patterns]
 author: adilei
 ---

--- a/_posts/2025-11-05-show-reasoning-agents-sdk.md
+++ b/_posts/2025-11-05-show-reasoning-agents-sdk.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post  
 title: "Showing Agent Reasoning in Custom UIs (Anthropic + Agents SDK)"  
 date: 2025-11-04 22:00:00 +0100  
-categories: [copilot-studio, tutorial, agents-sdk]
+categories: [agents-sdk]
 tags: [webchat, anthropic, reasoning, agents-sdk]  
 description: Surface Anthropic reasoning process as informative activities via the Microsoft 365 Agents SDK and render summarized reasoning steps in your app.  
 author: giorgioughini  

--- a/_posts/2025-11-11-copilot-studio-teams-deployment-ux.md
+++ b/_posts/2025-11-11-copilot-studio-teams-deployment-ux.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "Best Practices for Deploying Copilot Studio Agents in Microsoft Teams"
 date: 2025-11-14 17:30:00 +0100
-categories: [copilot-studio, teams, deployment]
+categories: [channels]
 tags: [teams-integration, session-management, state-management, troubleshooting]
 description: Essential techniques for managing session state, handling updates, and ensuring reliable performance when deploying Copilot Studio Agents to Microsoft Teams.
 author: raemone

--- a/_posts/2025-11-11-influence-orchestration-knowledge.md
+++ b/_posts/2025-11-11-influence-orchestration-knowledge.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "Influencing Agent Planning with Contextual Instructions"
 date: 2025-11-11 11:11:00 +0100
-categories: [copilot-studio, tutorial, orchestration]
+categories: [orchestration]
 tags: [instructions, planning, knowledge, mcp-server]
 description: How to provide additional context and influence agent behavior through instructions, including specific tools and knowledge consultation.
 author: giorgioughini

--- a/_posts/2025-11-11-mcs-http-connector-sso.md
+++ b/_posts/2025-11-11-mcs-http-connector-sso.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "(Nearly) Seamless Sign-In for Custom APIs in Copilot Studio"
 date: 2025-11-11
-categories: [copilot-studio, authentication, apis]
+categories: [authentication]
 tags: [entra-id, custom-apis, http-connector, authentication, delegated-permissions]
 author: adilei
 published: false

--- a/_posts/2025-11-14-unlocking-seamless-access-how-to-ensure-users-can-create-connections-for-copilot-studio-agents.md
+++ b/_posts/2025-11-14-unlocking-seamless-access-how-to-ensure-users-can-create-connections-for-copilot-studio-agents.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "Unlocking Seamless Access: How to Ensure Users Can Create Connections for Copilot Studio Agents"
 date: 2025-11-21
-categories: [copilot-studio, tutorial, governance, dataverse, security]
+categories: [automation]
 tags: [power-platform, agents, connection-references, connections, dataverse]
 description: Learn how to automatically sync users added/removed from Entra Security Groups to Dataverse Teams
 author: jpapadimitriou

--- a/_posts/2025-11-15-custom-connector-sso.md
+++ b/_posts/2025-11-15-custom-connector-sso.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "Enabling SSO for Custom Connectors in Copilot Studio"
 date: 2025-11-15
-categories: [copilot-studio, connectors, authentication]
+categories: [authentication]
 tags: [sso, custom-connectors, entra-id, authentication, api]
 description: How to configure custom connectors with Entra ID SSO to enable seamless user authentication and consent flow.
 #image: /assets/posts/custom-connector-sso/sso-flow.png

--- a/_posts/2025-11-18-you-dont-need-manual-auth.md
+++ b/_posts/2025-11-18-you-dont-need-manual-auth.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "You Probably Don't Need Manual Authentication (And Didn't Even Know It)"
 date: 2025-11-18
-categories: [copilot-studio, authentication]
+categories: [authentication]
 tags: [manual-auth, sso, authentication, best-practices, web-chat]
 description: Why most Copilot Studio agents don't need manual authentication, and the myths keeping you from simpler configurations.
 author: adilei

--- a/_posts/2025-11-19-a365-mcp-servers-copilot-studio.md
+++ b/_posts/2025-11-19-a365-mcp-servers-copilot-studio.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post  
 title: "Bringing Microsoft 365 Copilot into Copilot Studio with Agent 365 MCP Servers"  
 date: 2025-11-19 09:00:00 +0100  
-categories: [copilot-studio, frontier, mcp]
+categories: [mcp]
 tags: [a365, agent-365, frontier, copilot, sharepoint, outlook]  
 description: Use the new Agent 365 tooling servers to bring Microsoft 365 Copilot Search, SharePoint & OneDrive, Outlook Mail, Outlook Calendar, Word and more directly into your Copilot Studio agents. 
 author: giorgioughini

--- a/_posts/2025-11-25-mcp-resources-as-tool-inputs.md
+++ b/_posts/2025-11-25-mcp-resources-as-tool-inputs.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post    
 title: "Free Up Your Context Window: Pass MCP Resources, Not Raw Data"    
 date: 2025-11-24 23:50:00 +0100    
-categories: [copilot-studio, mcp, patterns]
+categories: [mcp]
 tags: [context-window, resources, mcp-server, tooling, scalability]    
 description: How to avoid context window saturation in Copilot Studio by passing MCP resources between tools when the tool output is too huge to fit into an agent context window.    
 author: giorgioughini    

--- a/_posts/2025-11-27-copilot-studio-handover-live-agent.md
+++ b/_posts/2025-11-27-copilot-studio-handover-live-agent.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "Handing Over to Live Agents Without Losing Control"
 date: 2025-12-14
-categories: [copilot-studio, tutorial, integration]
+categories: [channels]
 tags: [handover, escalation, live-chat, skills, proactive-messaging, microsoft-teams]
 description: Keep Copilot Studio in control while seamlessly handing off conversations to live agents using skills and Teams proactive messaging.
 author: mawasile    

--- a/_posts/2025-12-02-copilot-studio-a2a-multi-agents.md
+++ b/_posts/2025-12-02-copilot-studio-a2a-multi-agents.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post  
 title: "Quickstart: Connect an A2A Agent to Copilot Studio"  
 date: 2025-12-02 14:00:00 +0100  
-categories: [copilot-studio, a2a, connections]
+categories: [orchestration]
 tags: [a2a-protocol, agent-sdk, foundry, microsoft-365, integration]  
 description: Step-by-step guide to wiring an A2A-enabled agent into Copilot Studio.  
 author: giorgioughini  

--- a/_posts/2025-12-05-obo-for-custom-connectors.md
+++ b/_posts/2025-12-05-obo-for-custom-connectors.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "Seamless SSO with Custom Connectors (Yes It's Possible!)"
 date: 2025-12-05
-categories: [copilot-studio, authentication]
+categories: [authentication]
 tags: [manual-auth, sso, authentication, best-practices]
 description:  Avoiding the dreaded connection manager dialog for slick authenticated access to custom APIs and MCP servers.
 author: daveburman-msft

--- a/_posts/2025-12-10-custom-api-and-mcp-in-declarative-agents.md
+++ b/_posts/2025-12-10-custom-api-and-mcp-in-declarative-agents.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post      
 title: "VIDEO TUTORIAL: Add Custom APIs and MCP Servers to Declarative Agents"      
 date: 2025-12-10 9:00:00 +0100      
-categories: [copilot-studio, declarative-agents, video]
+categories: [automation]
 tags: [custom-api, mcp-server, agent-builder, m365-copilot, tutorial]      
 description: Short video walkthrough on how to plug custom HTTP APIs and MCP servers into Declarative Agents.      
 author: giorgioughini      

--- a/_posts/2025-12-13-A2A-Dad-jokes-Building-Python-Agents-with-Microsoft-365-SDK-for-MCS.md
+++ b/_posts/2025-12-13-A2A-Dad-jokes-Building-Python-Agents-with-Microsoft-365-SDK-for-MCS.md
@@ -488,6 +488,6 @@ Happy coding! 🎉
 
 ---
 
-*Written by Roel Schenk, Microsoft Copilot Studio Customer Advisory Team*
+*Written by Roel Schenk, Microsoft Copilot Acceleration Team*
 
 *Have questions or feedback? Drop a comment below or reach out to the team!*

--- a/_posts/2025-12-13-A2A-Dad-jokes-Building-Python-Agents-with-Microsoft-365-SDK-for-MCS.md
+++ b/_posts/2025-12-13-A2A-Dad-jokes-Building-Python-Agents-with-Microsoft-365-SDK-for-MCS.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "From Dad Jokes to A2A: Building Python Agents That Talk to Copilot Studio"
 date: 2025-12-13
-categories: [copilot-studio, a2a, agents-sdk]
+categories: [agents-sdk]
 tags: [copilot-studio, python, a2a, activity-protocol, agents-sdk, multi-agent, tutorial]
 description: "Learn how to extend Copilot Studio with Python agents using the Microsoft 365 Agents SDK and both Activity Protocol and Agent-to-Agent (A2A) communication"
 author: roels

--- a/_posts/2025-12-15-connecting-snfl-to-mcs.md
+++ b/_posts/2025-12-15-connecting-snfl-to-mcs.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "Connecting Snowflake to Copilot Studio: Step-by-Step Guide"
 date: 2025-12-15 17:30:00 +0100
-categories: [copilot-studio, knowledge-sources, tools]
+categories: [knowledge]
 tags: [knowledge, snowflake, connectors, mcs-tools, mcs-knowledge]
 description: By following this comprehensive guide, you've successfully connected Snowflake to Copilot Studio, enabling your agents to query live data through natural language.
 author: hasharaf

--- a/_posts/2025-12-15-remove-citations-in-copilot-studio-answer.md
+++ b/_posts/2025-12-15-remove-citations-in-copilot-studio-answer.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "Kill the [1]: How to Remove Citations from Copilot Studio Answers"
 date: 2025-12-15
-categories: [copilot-studio, generative-ai]
+categories: [knowledge]
 tags: [knowledge, citations, formatting, power-fx, pro-code]
 description: When citations get in the way of the experience, here is how to remove them from Copilot Studio answers.
 author: henryjammes

--- a/_posts/2025-12-16-connect-foundry-agents-in-copilotstudio.md
+++ b/_posts/2025-12-16-connect-foundry-agents-in-copilotstudio.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post  
 title: "Video Demo: Connect a Microsoft Foundry agent in Copilot Studio"  
 date: 2025-12-16 14:32:00 +0100  
-categories: [copilot-studio, foundry-agent, connectedagent, a2a]
+categories: [orchestration]
 tags: [a2a, agent, foundry, copilotstudio, connected-agent, multi-agent, integration, orchestration]  
 description: Quick illustration of integrating Foundry agents with Copilot Studio  
 author: jpad5  

--- a/_posts/2026-01-02-adaptive-card-generation.md
+++ b/_posts/2026-01-02-adaptive-card-generation.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "{Brace Yourself} - or Let Copilot Do It! Zero-100 with Adaptive Cards"
 date: 2026-01-02
-categories: [copilot-studio, user-experience]
+categories: [channels]
 tags: [adaptive-cards, best-practices, tips]
 description:  Stop hand cranking Adaptive Card JSON - put your effort into avoiding it!
 author: daveburman-msft

--- a/_posts/2026-01-08-localize-adaptive-cards.md
+++ b/_posts/2026-01-08-localize-adaptive-cards.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "The One Card: Build Once, Speak All Languages"
 date: 2026-01-08
-categories: [copilot-studio, localization]
+categories: [channels]
 tags: [adaptive-cards, multilingual, localization, best-practices]
 description: Static text in Adaptive Cards now appears in localization files, making multilingual agents with rich UI components actually practical.
 author: adilei

--- a/_posts/2026-01-09-cua-cloudpcpool-in-copilotstudio.md
+++ b/_posts/2026-01-09-cua-cloudpcpool-in-copilotstudio.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post  
 title: "Video Demo: Implement Cloud PC Pool for Computer Use in Microsoft Copilot Studio"  
 date: 2026-01-09 16:44:00 +0100  
-categories: [copilot-studio, computeruse, cua, cloudpcpool]
+categories: [mcp]
 tags: [cua, agent, computeruse, cloudpcpool, cloudpc, hostedbrowser, noapiagent, ai-bot, agentautomation]  
 description: Learn about Cloud PC pool for Computer Use in Microsoft Copilot Studio
 author: jpad5  

--- a/_posts/2026-01-10-search-enabled.md
+++ b/_posts/2026-01-10-search-enabled.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "Search Enabled: Powering The Custom Engine Blog with Algolia"
 date: 2026-01-10 00:00:00 +0100
-categories: [blog, search]
+categories: [knowledge]
 tags: [algolia, search, jekyll, instantsearch, user-experience]
 description: How we implemented Algolia-powered search to make finding technical content faster and more intuitive for the MCS CAT Blog.
 author: daveburman-msft

--- a/_posts/2026-01-11-mocked-webchat-welcome-message.md
+++ b/_posts/2026-01-11-mocked-webchat-welcome-message.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "The Welcome Message That Never Was: Mocking Agent Greetings in WebChat"
 date: 2026-01-11
-categories: [copilot-studio, webchat]
+categories: [channels]
 tags: [webchat, directline, welcome-message, redux, javascript]
 description: "Show a welcome message in WebChat without triggering your agent—because sometimes the best conversation is the one that never started."
 author: adilei

--- a/_posts/2026-01-16-response-analysis-copilot-tool.md
+++ b/_posts/2026-01-16-response-analysis-copilot-tool.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "Agentic Tooling: Making Agent Performance Transparent and Measurable"
 date: 2026-01-16
-categories: [generative-ai, custom-engine, blog, copilot-studio]
+categories: [agents-sdk]
 tags: [pro-code, tutorial, api-integration, planning, orchestration, performance-monitoring]
 description: "Build a tool for Copilot Studio agents that provides real-time performance metrics and agent execution insights during development using M 365 Agent SDK."
 author: kaul-vineet

--- a/_posts/2026-01-23-copilot-studio-defeating-oversummarization.md
+++ b/_posts/2026-01-23-copilot-studio-defeating-oversummarization.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "Defeating Oversummarization in AI Agents: How to Deliver Exact Content from Knowledge Sources"
 date: 2026-01-23 12:00:00 +0100
-categories: [copilot-studio, knowledge, rag]
+categories: [knowledge]
 tags: [generative-ai, summarization, knowledge-sources, custom-search]
 description: Learn three methods to return exact, unsummarized content from Copilot Studio knowledge sources when precision matters more than simplification.
 author: dbellingeri

--- a/_posts/2026-01-24-conversationid-users.md
+++ b/_posts/2026-01-24-conversationid-users.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "How to Get Your Conversation ID When Chatting with Agents"
 date: 2026-01-24 00:00:00 +0000
-categories: [copilot-studio, generative-ai]
+categories: [testing]
 tags: [conversationid, troubleshooting, support, debugging]
 description: A guide for end-users about how to get a Conversation ID to get help quickly with Copilot Studio agents in Microsoft 365 Copilot, Microsoft Teams, web chat, and other chat surfaces
 author: chrisgarty

--- a/_posts/2026-01-26-meeting-transcript-analyzer.md
+++ b/_posts/2026-01-26-meeting-transcript-analyzer.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post      
 title: "VIDEO: Retrieve Meeting Transcripts in Copilot Studio & Block Focus Time"      
 date: 2026-01-26 9:00:00 +0100      
-categories: [copilot-studio, autonomous-agents, video]
+categories: [knowledge]
 tags: [microsoft-teams, outlook, meeting-transcripts, productivity, tutorial]
 description: Watch an autonomous agent analyze your daily meeting transcripts and automatically block focus time for open action items.
 author: giorgioughini

--- a/_posts/2026-01-26-webchat-embed-zero-javascript.md
+++ b/_posts/2026-01-26-webchat-embed-zero-javascript.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "Embedding WebChat Without Writing a Single Line of JavaScript"
 date: 2026-01-26
-categories: [copilot-studio, webchat]
+categories: [channels]
 tags: [webchat, copilot-studio, embedding, javascript, html, cdn, unauthenticated-agents, widget]
 description: "A new library that lets you embed BotFramework WebChat into any website using only HTML data attributes. No JavaScript knowledge required."
 author: adilei

--- a/_posts/2026-01-29-compare-mcp-servers-pp-connectors.md
+++ b/_posts/2026-01-29-compare-mcp-servers-pp-connectors.md
@@ -3,7 +3,7 @@ agent_edition: both
 layout: post
 title: "MCP Servers or Connectors in Copilot Studio? A Maker's Guide"
 date: 2026-02-13 12:00:00 +0100
-categories: [copilot-studio, mcp, connectors]
+categories: [automation]
 tags: [mcp, connectors, custom-connector, agent-365, copilot-studio, power-platform, decision-guide, enterprise]
 description: "A practical guide for Copilot Studio makers choosing between MCP servers and Power Platform connectors, covering both built-in options and custom builds."
 author: jpad5

--- a/_posts/2026-02-02-webchat-middlewares.md
+++ b/_posts/2026-02-02-webchat-middlewares.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "VIDEO: Mastering WebChat Middleware for Copilot Studio Agents"
 date: 2026-02-02 9:00:00 +0100
-categories: [copilot-studio, webchat, video]
+categories: [channels]
 tags: [webchat, bot-framework, direct-line, redux, middleware, tutorial]
 description: Watch how to intercept, modify, and control message flow in WebChat using Redux middleware - and why you should use WebChat instead of building custom chat UIs.
 author: giorgioughini

--- a/_posts/2026-02-11-dynamic-knowledge-urls-copilot-studio.md
+++ b/_posts/2026-02-11-dynamic-knowledge-urls-copilot-studio.md
@@ -4,7 +4,7 @@ layout: post
 title: "Zero Noise, Maximum Relevance: Dynamic Knowledge URLs in Copilot Studio"
 date: 2026-02-11 00:00:00 +0000
 last_modified_at: 2026-03-10 00:00:00 +0000
-categories: [copilot-studio, knowledge]
+categories: [knowledge]
 tags: [knowledge-sources, dynamic-urls, public-website, alm, multi-region, powerfx, topic-inputs, variables, table-variables]
 description: How a simple variable unlocks multi-market, multi-language, and multi-product web grounding while improving ALM processes.
 author: dbellingeri

--- a/_posts/2026-02-20-webchat-conversation-history-m365-sdk.md
+++ b/_posts/2026-02-20-webchat-conversation-history-m365-sdk.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "The Conversation History Gap in the M365 Agents SDK (And How We Filled It)"
 date: 2026-02-20
-categories: [copilot-studio, webchat]
+categories: [channels]
 tags: [webchat, m365-agents-sdk, conversation-history, directline, streaming, activity-protocol, typescript]
 description: "The M365 Agents SDK doesn't support fetching past activities. Here's how we solved conversation resumption and history for a customer's multi-agent WebChat app."
 author: adilei

--- a/_posts/2026-02-24-servicenow-copilot-studio-widget.md
+++ b/_posts/2026-02-24-servicenow-copilot-studio-widget.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "Embedding Copilot Studio Directly in ServiceNow (And Why Auth Was the Easy Part)"
 date: 2026-02-24
-categories: [copilot-studio, webchat]
+categories: [channels]
 tags: [servicenow, webchat, m365-agents-sdk, msal, authentication, field-report, widget, service-portal]
 description: "A field report on embedding a Copilot Studio agent as a native floating chat widget in ServiceNow Service Portal, with MSAL auth that sidesteps federation complexity."
 author: adilei

--- a/_posts/2026-03-02-copilot-studio-api-decision-guide.md
+++ b/_posts/2026-03-02-copilot-studio-api-decision-guide.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "Every Path to Integrating Your Copilot Studio Agent"
 date: 2026-03-02
-categories: [copilot-studio, tutorial]
+categories: [channels]
 tags: [direct-line, webchat, m365-agents-sdk, sso, embed, teams, api, decision-guide, byo-ui]
 description: "An interactive decision wizard that helps you pick the right integration pattern for your Copilot Studio agent, from no-code embeds to native mobile apps, custom UIs, and server-side connectors."
 author: adilei

--- a/_posts/2026-03-03-connecting-copilot-studio-dataverse-mcp-endpoint-across-environments.md
+++ b/_posts/2026-03-03-connecting-copilot-studio-dataverse-mcp-endpoint-across-environments.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "Connecting Copilot Studio to a Dataverse MCP Endpoint Across Environments: A Practical Guide"
 date: 2026-03-03 00:00:00 +0000
-categories: [copilot-studio, mcp]
+categories: [mcp]
 tags:
   [
     dataverse,

--- a/_posts/2026-03-06-copilot-studio-kit.md
+++ b/_posts/2026-03-06-copilot-studio-kit.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "Copilot Studio Kit: Beyond Test Automation"
 date: 2026-03-06
-categories: [copilot-studio-kit, copilot-studio]
+categories: [alm]
 tags: [test-automation, governance, compliance, agent-inventory, conversation-analytics, rubric-refinement, webchat-customization, adaptive-cards]
 description: "A deep look at Copilot Studio Kit's full feature set, from test automation and rubric refinement to agent inventory, compliance governance, and webchat customization."
 author: psimolin

--- a/_posts/2026-03-10-skills-for-copilot-studio.md
+++ b/_posts/2026-03-10-skills-for-copilot-studio.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "Skills for Copilot Studio: Build agents from YAML code, up to 20x Faster"
 date: 2026-03-10 9:00:00 +0100
-categories: [copilot-studio, tutorial, open-source]
+categories: [mcp]
 tags: [claude-code, github-copilot, yaml, agent-development, productivity]
 description: An open-source plugin for Claude Code and GitHub Copilot that lets you author, test, and troubleshoot Copilot Studio agents directly from your terminal.
 author: giorgioughini

--- a/_posts/2026-03-13-power-of-topics-copilot-studio.md
+++ b/_posts/2026-03-13-power-of-topics-copilot-studio.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "The Orchestrator’s Secrets: Chain-of-Thought & Transcript on Demand"
 date: 2026-03-17 00:00:00 +0000
-categories: [copilot-studio, tutorial]
+categories: [orchestration]
 tags:
   [
     topics,

--- a/_posts/2026-03-13-salesforce-copilot-studio-handoff.md
+++ b/_posts/2026-03-13-salesforce-copilot-studio-handoff.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "Salesforce Handoff to Copilot Studio: From Bare Docs to One-Click Deploy"
 date: 2026-03-13
-categories: [copilot-studio, integration]
+categories: [channels]
 tags: [salesforce, einstein-bot, direct-line, handoff, engagement-hub, apex, deployment-script]
 description: "The Copilot Studio + Salesforce Einstein Bot integration docs got a major overhaul: full Apex code samples, Named Credentials for secure auth, and deployment scripts that do everything for you."
 author: adilei

--- a/_posts/2026-03-19-open-the-hood-copilot-studio-transcripts.md
+++ b/_posts/2026-03-19-open-the-hood-copilot-studio-transcripts.md
@@ -5,7 +5,7 @@ title: "Open the Hood: What Your Copilot Studio Agent Is Really Doing"
 description: "How to extract, read, and understand Copilot Studio conversation transcripts so you know what your agent is doing and why."
 date: 2026-03-19
 author: roels
-categories: [copilot-studio, tutorial]
+categories: [testing]
 tags: [transcripts, dataverse, application-insights, power-apps, copilot-studio-kit, debugging, analytics]
 image:
   path: /assets/posts/conversation-transcripts/header.png

--- a/_posts/2026-03-19-open-the-hood-technical-reference.md
+++ b/_posts/2026-03-19-open-the-hood-technical-reference.md
@@ -5,7 +5,7 @@ title: "Open the Hood: Technical Reference for Copilot Studio Transcripts"
 description: "Data model deep-dive, Dataverse vs Application Insights comparison, and all six transcript access methods with code examples."
 date: 2026-03-19
 author: roels
-categories: [copilot-studio, tutorial]
+categories: [testing]
 tags: [transcripts, dataverse, application-insights, power-apps, copilot-studio-kit, debugging, analytics, kql, data-model]
 image:
   path: /assets/posts/conversation-transcripts/header-technical-reference.png

--- a/_posts/2026-03-20-dataverse-search-in-copilot-studio-unauthenticated-structured-data.md
+++ b/_posts/2026-03-20-dataverse-search-in-copilot-studio-unauthenticated-structured-data.md
@@ -2,7 +2,7 @@
 agent_edition: standard
 title: "Structured Data with Zero User Auth: Dataverse searchQuery in Copilot Studio"
 date: 2026-03-20
-categories: [copilot-studio, dataverse]
+categories: [knowledge]
 tags: [copilot studio, dataverse, searchquery, unauthenticated, agentic, enterprise-grade]
 description: "Build fuzzy, ranked search over Dataverse structured data with zero user sign-in. A step-by-step guide from indexing to a working agent, with progressive enhancements for OData filtering, pagination, and full record retrieval."
 author: KarimaKT

--- a/_posts/2026-03-26-claude-copilot-skills-copilot-studio-plugin-demo.md
+++ b/_posts/2026-03-26-claude-copilot-skills-copilot-studio-plugin-demo.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "Live Demo: Using the Claude Code Plugin to Author a Copilot Studio Agent"
 date: 2026-03-26 9:00:00 +0100
-categories: [copilot-studio, plugin, video]
+categories: [mcp]
 tags: [claude-code, copilot-studio, plugin, agent-authoring, yaml, tutorial]
 description: Watch a full live demo of building a complex Copilot Studio agent from scratch using the Claude Code plugin - from cloning to pushing, all in one session.
 author: giorgioughini

--- a/_posts/2026-03-27-dynamic-mcp-routing-copilot-studio.md
+++ b/_posts/2026-03-27-dynamic-mcp-routing-copilot-studio.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "Dynamic MCP Routing in Copilot Studio: One Connector, Many Endpoints"
 date: 2026-03-27
-categories: [copilot-studio, mcp]
+categories: [mcp]
 tags: [mcp, custom-connector, connectors, enterprise-patterns, power-platform, dynamic-routing, model-context-protocol]
 description: "How to route a single Copilot Studio connector to multiple MCP endpoints using a catalog service, dynamic Swagger dropdowns, and C# URL rewriting."
 author: adilei

--- a/_posts/2026-03-29-agentic-improvement-loop.md
+++ b/_posts/2026-03-29-agentic-improvement-loop.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "Closing the Loop: Automated Agent Improvement with Publish and Test"
 date: 2026-03-29
-categories: [copilot-studio, testing]
+categories: [testing]
 tags: [plugin, orchestration, deepeval, testing, m365-agents-sdk]
 description: "We added a publish command to the Copilot Studio plugin, enabling an automated edit-push-publish-test loop. A trial run on a D&D rules agent shows the progression from blank instructions to a stable 60% pass rate across 7 iterations."
 author: adilei

--- a/_posts/2026-04-01-connecting-legacy-desktop-apps-to-copilot-studio.md
+++ b/_posts/2026-04-01-connecting-legacy-desktop-apps-to-copilot-studio.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "Bridging the Gap: Connecting Legacy Desktop Applications to Copilot Studio Agents"
 date: 2026-04-15
-categories: [copilot-studio, agents]
+categories: [automation]
 tags: [computer-use, agents, power-automate, rpa, legacy, desktop, dataverse, robotic-process-automation, cua]
 description: "A technical deep-dive into connecting legacy desktop applications to Microsoft Copilot Studio agents - exploring how a Separation of Concerns pattern lets you reuse your existing RPA stack today, and how Computer Use Agents (CUA) enable a fully agentic alternative."
 author: jpapadimitriou

--- a/_posts/2026-04-07-copilot-studio-teams-agent-patterns.md
+++ b/_posts/2026-04-07-copilot-studio-teams-agent-patterns.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "Design Copilot Studio Agents for Teams (Because Test Chat Was Too Easy)"
 date: 2026-04-07
-categories: [copilot-studio, teams]
+categories: [channels]
 tags: [teams, microsoft-365-copilot, conversation-management, troubleshooting, adaptive-cards]
 description: Eight production patterns for designing Copilot Studio agents that work well in Teams and Microsoft 365 Copilot - handling reinstalls, context management, error handling, and self-service troubleshooting with diagnostic cards.
 author: henryjammes

--- a/_posts/2026-04-07-copilot-studio-teams-deployment.md
+++ b/_posts/2026-04-07-copilot-studio-teams-deployment.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "From DEV to PROD: Deploying Copilot Studio Agents to Teams and Microsoft 365 Copilot"
 date: 2026-04-07
-categories: [copilot-studio, teams, deployment]
+categories: [channels]
 tags: [teams-deployment, admin-center, setup-policies, app-manifest, alm, environment-strategy, auto-install, microsoft-365-copilot]
 description: "Master the three deployment paths for Copilot Studio agents in Teams and Microsoft 365 Copilot. Learn how to customize manifests for DEV/TEST environments, leverage Setup Policies for auto-install and pinning, and deploy to M365 Copilot through the Admin Center."
 author: henryjammes

--- a/_posts/2026-04-10-dataverse-retrieval-patterns-copilot-studio.md
+++ b/_posts/2026-04-10-dataverse-retrieval-patterns-copilot-studio.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "Dataverse Retrieval Patterns for Structured Data in Copilot Studio Agents"
 date: 2026-04-10
-categories: [copilot-studio, dataverse]
+categories: [knowledge]
 tags: [dataverse, retrieval-patterns, knowledge, list-rows, mcp, searchquery, prompt-tool, connectors, decision-guide]
 description: "Five ways to retrieve Dataverse data from Copilot Studio agents — Knowledge, List Rows, MCP Server, Search Query, and Prompt Tool. A decision guide with setup steps and trade-offs, flow charts and a handy interactive widget to help you pick the right method."
 authors: [KarimaKT, roels]

--- a/_posts/2026-04-10-hello-world-mcp-copilot-studio.md
+++ b/_posts/2026-04-10-hello-world-mcp-copilot-studio.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "Five Minutes to Your First MCP Connector in Copilot Studio"
 date: 2026-04-10
-categories: [copilot-studio, mcp]
+categories: [mcp]
 tags: [mcp, custom-connectors, alm, connection-references, a2a, solutions, copilot-studio]
 description: "Create your first MCP connector in Copilot Studio in five minutes, then understand what was created behind the scenes: custom connectors, connection references, and solution structure."
 author: chrisgarty

--- a/_posts/2026-04-17-combining-agent-flows-and-agents-gotchas-errors-and-patterns.md
+++ b/_posts/2026-04-17-combining-agent-flows-and-agents-gotchas-errors-and-patterns.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "Combining Agent Flows with Agents: Gotchas, Errors, and Patterns"
 date: 2026-04-17
-categories: [copilot-studio, tutorial]
+categories: [automation]
 tags: [power-automate, agent-flows, troubleshooting, async-pattern, maker-credentials, approvals, flow-timeout]
 description: "Best practices and common issues when deploying solutions that combine agent flows with agents in Copilot Studio — timeouts, credentials, schema mismatches, collaboration, and more."
 author: PetrosFeleskouras

--- a/_posts/2026-04-17-embed-copilot-studio-agents-canvas-apps.md
+++ b/_posts/2026-04-17-embed-copilot-studio-agents-canvas-apps.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "Embed Copilot Studio Agents in Canvas Apps with a PCF Control"
 date: 2026-04-17
-categories: [copilot-studio, canvas-apps]
+categories: [channels]
 tags: [canvas-apps, pcf, webchat, power-apps, embed, m365-agents-sdk, sso]
 description: "The built-in Copilot control for Canvas Apps is deprecated. Use this PCF control to embed your Copilot Studio agent with custom styling and two-way communication."
 author: dieterd-msft

--- a/_posts/2026-04-17-no-copilot-license-m365-channel.md
+++ b/_posts/2026-04-17-no-copilot-license-m365-channel.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "No, You Don't Need a Copilot License to Deploy Agents to Microsoft 365 Copilot"
 date: 2026-04-17
-categories: [copilot-studio, microsoft-365-copilot]
+categories: [alm]
 tags: [microsoft-365-copilot, declarative-agents, copilot-chat, copilot-credits, agent-builder, licensing, teams, alm]
 description: "Microsoft 365 Copilot isn't just for licensed Copilot users. Learn how to deploy Copilot Studio agents to Copilot Chat users, how declarative agents are evolving, and why you no longer need an Azure subscription for prepaid capacity."
 author: henryjammes

--- a/_posts/2026-04-19-copilot-studio-eval-gate-azure-devops.md
+++ b/_posts/2026-04-19-copilot-studio-eval-gate-azure-devops.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "Quality Gates for Copilot Studio: Automated Evaluations in Azure DevOps"
 date: 2026-04-19
-categories: [copilot-studio, testing]
+categories: [testing]
 tags: [evaluation-api, azure-devops, ci-cd, quality-gate, testing, alm, pac-cli, power-platform]
 description: "How to use the Copilot Studio Evaluation API to build automated quality gates in Azure DevOps pipelines, blocking PR merges when agent quality drops below threshold."
 author: adilei

--- a/_posts/2026-04-28-webchat-context-variables.md
+++ b/_posts/2026-04-28-webchat-context-variables.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "How to Set Context Variables to Copilot Studio Agents Using WebChat"
 date: 2026-04-28 9:00:00 +0100
-categories: [copilot-studio, webchat]
+categories: [channels]
 tags: [botframework-webchat, webchat, redux, middleware, m365-agents-sdk, directline, context-variables]
 description: "Learn how to reliably pass context variables to Copilot Studio agents via WebChat using a Redux middleware that works on both Direct Line and the M365 Agents SDK."
 author: giorgioughini

--- a/_posts/2026-04-30-tool-inputs-sharepoint-list.md
+++ b/_posts/2026-04-30-tool-inputs-sharepoint-list.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "Get Answers Over SharePoint Lists and Other Structured Data — Turning Natural Language into Dynamic Queries in Copilot Studio"
 date: 2026-04-30
-categories: [copilot-studio, connectors]
+categories: [automation]
 tags: [sharepoint, connectors, orchestration, retrieval-patterns, odata, tools, inputs, nl2query, decision-guide, work-iq]
 description: "How to turn natural language into OData queries over SharePoint list data using Copilot Studio connector tools with dynamic inputs — from a one-tool starter to production patterns with dynamic schemas, semantic search, and response shaping."
 author: KarimaKT

--- a/_posts/2026-05-07-managing-azure-consumption-power-platform.md
+++ b/_posts/2026-05-07-managing-azure-consumption-power-platform.md
@@ -3,7 +3,7 @@ agent_edition: both
 layout: post
 title: "Real-Time PAYG Overage Protection with Power Automate, Custom Connectors"
 date: 2026-05-07
-categories: [copilot-studio, power-platform]
+categories: [alm]
 tags: [power-automate, custom-connector, azure-cost-management, billing-policy, payg, governance, power-platform]
 description: "Build a fully native Power Platform solution for real-time PAYG overage protection using a scheduled cloud flow, the Azure Cost Management API, and the Power Platform Admin V2 connector."
 author: rranjit

--- a/_posts/2026-05-12-bulk-file-testing-copilot-evals.md
+++ b/_posts/2026-05-12-bulk-file-testing-copilot-evals.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "Bulk File-Based Testing for Copilot Studio: Beyond Standard Evals"
 date: 2026-05-12
-categories: [copilot-studio, testing]
+categories: [testing]
 tags: [evals, testing, dataverse, power-automate, sharepoint, bulk-testing, power-bi, file-processing]
 description: "How to build a scalable bulk file-based testing framework for Copilot Studio agents using Dataverse, SharePoint, Power Automate, and Power BI when standard evals aren't enough."
 author: ashVancouver

--- a/_posts/2026-05-13-managing-spend-pay-as-you-go.md
+++ b/_posts/2026-05-13-managing-spend-pay-as-you-go.md
@@ -3,7 +3,7 @@ agent_edition: both
 layout: post
 title: "Herding Clouds: Taming Pay-As-You-Go Billing Policies in Power Platform at Scale"
 date: 2026-05-13
-categories: [copilot-studio, licensing]
+categories: [alm]
 tags: [pay-as-you-go, billing-policy, power-automate, governance, azure-automation, power-platform, licensing, powershell]
 mermaid: true
 description: "Assigning billing policies to 50+ environments by hand doesn't scale, and nobody reads the budget alert email before Monday. This post walks through a bulk assignment script and an automated unlinking pipeline that solve both problems."

--- a/_posts/2026-05-15-atlassian-jira-remote-mcp-copilot-studio.md
+++ b/_posts/2026-05-15-atlassian-jira-remote-mcp-copilot-studio.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "Wiring up the Jira (Atlassian) Remote MCP server in Copilot Studio in 5 mins"
 date: 2026-05-15
-categories: [copilot-studio, mcp]
+categories: [mcp]
 tags: [mcp, atlassian, jira, oauth, dynamic-client-registration, authentication]
 description: "The Atlassian Remote MCP server uses Dynamic Client Registration. If you wire it up with Manual OAuth in Copilot Studio you'll waste an afternoon. Use Dynamic discovery and a few Atlassian admin toggles, and you're done in five minutes."
 author: hasharaf

--- a/_posts/2026-05-19-pdf-page-level-citations.md
+++ b/_posts/2026-05-19-pdf-page-level-citations.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "Page-Level PDF Citations in Copilot Studio"
 date: 2026-06-02
-categories: [copilot-studio, knowledge]
+categories: [knowledge]
 tags: [citations, pdf, sharepoint, knowledge-sources, power-fx, generative-orchestration, unstructured-data]
 description: "How to deliver page-level PDF citations in Copilot Studio for SharePoint and uploaded file knowledge sources, so users land on the exact page that grounded the answer."
 author: [lewisdoesdev, raemone]

--- a/_posts/2026-05-20-alm-copilot-studio-agents-foundation.md
+++ b/_posts/2026-05-20-alm-copilot-studio-agents-foundation.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "ALM for Copilot Studio Agents: The Foundation"
 date: 2026-06-03
-categories: [copilot-studio, alm]
+categories: [alm]
 tags: [copilot-studio, power-platform, alm, environments, solutions, pipelines, connection-references]
 description: "The fundamentals of Application Lifecycle Management for Copilot Studio agents: environments, solutions, publishers, and pipelines - the safe baseline every maker should have in place."
 author: jpapadimitriou

--- a/_posts/2026-05-20-human-in-the-loop-custom-connector.md
+++ b/_posts/2026-05-20-human-in-the-loop-custom-connector.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "Building a Custom Human-in-the-Loop Experience for Copilot Studio Workflows"
 date: 2026-05-20
-categories: [copilot-studio, connectors]
+categories: [automation]
 tags: [custom-connector, power-automate, webhook, workflows, human-review, openapi]
 description: "When every workflow approval is another email in someone's inbox, something has gone wrong. A custom connector pattern that lets Copilot Studio workflows pause for human input and resume through any UI you want."
 author: adilei

--- a/_posts/2026-05-22-snowflake-mcp-copilot-studio.md
+++ b/_posts/2026-05-22-snowflake-mcp-copilot-studio.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "Wiring up a Snowflake-managed MCP server in Copilot Studio"
 date: 2026-05-22
-categories: [copilot-studio, mcp]
+categories: [mcp]
 tags: [mcp, snowflake, cortex, oauth, entra-id, copilot-studio, power-platform]
 description: "An end-to-end walkthrough for wiring a Snowflake-managed MCP server into a Microsoft Copilot Studio agent with delegated user OAuth through Microsoft Entra ID, including the Cortex Agent prerequisite, the manual OAuth path Snowflake actually requires, and the small details that make or break the setup."
 authors: [hasharaf, missbets]

--- a/_posts/2026-06-14-agent-authentication-controls.md
+++ b/_posts/2026-06-14-agent-authentication-controls.md
@@ -3,7 +3,7 @@ agent_edition: standard
 layout: post
 title: "The Admin Control That Closes the Door Before \"Hello\""
 date: 2026-06-14
-categories: [copilot-studio, governance]
+categories: [alm]
 tags: [authentication, governance, data-loss-prevention, direct-line, m365-agents-sdk, admin, entra-id, employee-facing]
 description: "A new Power Platform admin control lets you govern how users authenticate to Copilot Studio agents, and it answers a question that DLP channel blocking never could."
 author: adilei

--- a/_posts/2026-06-15-modern-mcs-agent-skills.md
+++ b/_posts/2026-06-15-modern-mcs-agent-skills.md
@@ -3,7 +3,7 @@ layout: post
 agent_edition: github-copilot
 title: "Agents Have Skills Now — Here's How They Work in Copilot Studio"
 date: 2026-06-15
-categories: [copilot-studio, skills]
+categories: [mcp]
 tags: [copilot-studio, skills, orchestration, agent-development, best-practices]
 description: "How Skills work in Copilot Studio agents: instructions and resources loaded on demand for specific scenarios, why you would modularize instructions into Skills, and when to use Skills versus instructions."
 author: roels

--- a/_posts/2026-06-26-better-llm-scoring.md
+++ b/_posts/2026-06-26-better-llm-scoring.md
@@ -2,7 +2,7 @@
 layout: post
 title: "Stop Asking an LLM to \"Rate This 1-5\": A Better Way to Score with LLMs"
 date: 2026-06-26
-categories: [copilot-studio, patterns]
+categories: [testing]
 tags: [evals, testing, quality-gate, llm-as-judge, rubric-refinement, evaluation-api, generative-ai]
 description: 'Asking an LLM to "rate this 1-5" gives you a number that looks decisive but isn''t. Here''s how to build LLM scores you can actually defend.'
 author: [msmgp, serenaxxiee]

--- a/_posts/2026-07-07-new-orchestrator-resources.md
+++ b/_posts/2026-07-07-new-orchestrator-resources.md
@@ -3,7 +3,7 @@ agent_edition: github-copilot
 layout: post
 title: "New Harness, New Rules? CAT's Got You"
 date: 2026-07-07
-categories: [copilot-studio, orchestration]
+categories: [orchestration]
 tags: [copilot-studio, github-copilot, orchestration, upgrade, skills, agent-development]
 mermaid: false
 pin: true

--- a/_posts/2026-07-09-e3-users-build-agents-turn-it-off.md
+++ b/_posts/2026-07-09-e3-users-build-agents-turn-it-off.md
@@ -2,7 +2,7 @@
 layout: post
 title: "Why Your E3 Users Can Suddenly Build Agents in Copilot Studio — and How to Turn It Off"
 date: 2026-07-09
-categories: [copilot-studio, governance]
+categories: [alm]
 tags: [copilot-studio, licensing, governance, e3, teams, power-virtual-agents]
 description: "A recent redirect change surfaced classic agent creation in the Copilot Studio web app for basic-licensed users. Here's the single service plan admins can disable to govern it."
 author: emdarcy

--- a/_posts/2026-07-14-migration-plugin-video-demo.md
+++ b/_posts/2026-07-14-migration-plugin-video-demo.md
@@ -3,7 +3,8 @@ agent_edition: github-copilot
 layout: post
 title: "Video Demo: Upgrading a Classic Agent to Modern Orchestration"
 date: 2026-07-14 16:12:53 +0200
-categories: [copilot-studio, upgrade]
+pin: true
+categories: [orchestration]
 tags: [github-copilot, copilot-studio, plugin, upgrade, modern-agents, orchestration, skills, agent-development]
 description: "Watch GitHub Copilot CLI upgrade a classic Copilot Studio travel agent to modern orchestration with our newly released plugin, then explore how its capabilities become Skills and tools."
 author: giorgioughini

--- a/_posts/2026-07-15-redlining-documents-new-copilot-studio-experience.md
+++ b/_posts/2026-07-15-redlining-documents-new-copilot-studio-experience.md
@@ -3,7 +3,7 @@ agent_edition: github-copilot
 layout: post
 title: "Redlining Documents with the New Copilot Studio Experience"
 date: 2026-07-15
-categories: [copilot-studio, tutorial]
+categories: [orchestration]
 tags: [orchestration, pdf, document-comparison, track-changes, docx, redlining, agent-development]
 description: "Compare documents using Microsoft Word's Native Redlining Track Changes."
 author: [AndrewHessMSFT, raemone]

--- a/_posts/2026-07-20-copilot-studio-agent-sandbox.md
+++ b/_posts/2026-07-20-copilot-studio-agent-sandbox.md
@@ -3,7 +3,8 @@ layout: post
 agent_edition: github-copilot
 title: "The New Copilot Studio Agent Sandbox"
 date: 2026-07-20
-categories: [copilot-studio, agents]
+pin: true
+categories: [orchestration]
 tags: [copilot-studio, skills, agent-sandbox, code-execution, python, agent-development]
 description: "How the Copilot Studio agent sandbox turns model reasoning into finished files, calculations, and other executable work while keeping external access governed."
 author: chrisgarty

--- a/_posts/2026-07-28-podcast-script-skill.md
+++ b/_posts/2026-07-28-podcast-script-skill.md
@@ -3,7 +3,7 @@ agent_edition: github-copilot
 layout: post
 title: "Turn Your Daily Digest Into a Podcast You'll Actually Listen To"
 date: 2026-07-28
-categories: [copilot-studio, skills]
+categories: [mcp]
 tags: [skills, text-to-speech, ssml, azure-speech, productivity, agent-development, teams]
 description: "A Copilot Studio Skill that turns any document, email, or press review into a two-host podcast episode, with multi-voice SSML, an Azure Text to Speech endpoint, and an agent you can listen to from your phone."
 author: raemone

--- a/_tabs/about.md
+++ b/_tabs/about.md
@@ -7,11 +7,11 @@ order: 5
 
 # About The Custom Engine
 
-Welcome to **The Custom Engine** - the technical blog of the Microsoft Copilot Studio Customer Advisory Team (CAT).
+Welcome to **The Custom Engine** - the technical blog of the Microsoft Copilot Acceleration Team (CAT).
 
 ## Who Are We?
 
-The Copilot Studio Customer Advisory Team (CAT) is a part of the Copilot Studio engineering team at Microsoft. We are dedicated to empowering organizations to achieve digital transformation at scale with Microsoft Copilot Studio.
+The Copilot Acceleration Team (CAT) is a part of the Copilot Studio engineering team at Microsoft. We are dedicated to empowering organizations to achieve digital transformation at scale with Microsoft Copilot Studio.
 
 ## Our Mission
 

--- a/assets/css/jekyll-theme-chirpy.scss
+++ b/assets/css/jekyll-theme-chirpy.scss
@@ -10,135 +10,30 @@
 
 /* append your custom style below */
 
-/* Lighten the hover state so the gradient ring is the only strong color.
-   (Only touches the post list cards; leaves tags & other UI untouched.) */
+/* Brand gradient consumed by --ce-grad (hero accent, tile icons).
+   Brightened in dark mode so it stays vivid on dark surfaces. */
+:root {
+  --post-frame-gradient: linear-gradient(90deg,
+    #0078D4 0%,
+    #5B8DEF 18%,
+    #7F39FB 36%,
+    #C26CF3 54%,
+    #D83B73 72%,
+    #FF8C00 100%);
+}
 
-   :root {
-    --post-frame-radius: 14px;
-    --post-frame-thickness: 2px;
-    --post-frame-gradient: linear-gradient(90deg,
-      #0078D4 0%,
-      #5B8DEF 18%,
-      #7F39FB 36%,
-      #C26CF3 54%,
-      #D83B73 72%,
-      #FF8C00 100%);
-  }
-  
-  /* Wrapper hosts gradient ring */
-  #post-list .card-wrapper {
-    position: relative;
-    border-radius: var(--post-frame-radius);
-  }
-  
-  /* Override Chirpy's post-preview to remove its hover overlay */
-  #post-list .post-preview {
-    position: relative;
-    
-    /* Disable Chirpy's dark overlay on hover */
-    &::before {
-      display: none !important;
-    }
-    
-    /* Keep the card white in light mode, with very subtle gray on hover */
-    background: #ffffff;
-    transition: background-color .25s ease, box-shadow .25s ease, transform .25s ease;
-    
-    &:hover {
-      background: #fafafa; /* Very subtle gray */
-      box-shadow: 0 8px 20px rgba(0,0,0,.10);
-      transform: translateY(-2px);
-    }
-  }
-  
-  /* Base card surface */
-  #post-list .card-wrapper > .card {
-    border: none;
-    border-radius: var(--post-frame-radius);
-    position: relative;
-    z-index: 0;
-    background: #ffffff;
-    transition: background-color .25s ease, box-shadow .25s ease, transform .25s ease;
-  }
-  
-  /* Gradient ring only on hover/focus */
-  #post-list .card-wrapper::before {
-    content: "";
-    position: absolute;
-    inset: 0;
-    padding: var(--post-frame-thickness);
-    border-radius: inherit;
-    background: var(--post-frame-gradient);
-    opacity: 0;
-    transition: opacity .25s ease;
-    pointer-events: none;
-    -webkit-mask:
-      linear-gradient(#000 0 0) content-box,
-      linear-gradient(#000 0 0);
-    -webkit-mask-composite: xor;
-            mask-composite: exclude;
-    z-index: 1;
-  }
-  
-  /* Show ring */
-  #post-list .card-wrapper:hover::before,
-  #post-list .card-wrapper:focus-within::before {
-    opacity: 1;
-  }
-  
-  /* Force subtle gray hover surface */
-  #post-list .card-wrapper:hover > .card,
-  #post-list .card-wrapper:focus-within > .card,
-  #post-list .card-wrapper:hover > .post-preview,
-  #post-list .card-wrapper:focus-within > .post-preview {
-    background: #fafafa; /* Very subtle gray */
-    box-shadow: 0 8px 20px rgba(0,0,0,.10);
-    transform: translateY(-2px);
-  }
-  
-  /* Override Chirpy's potential hover styles */
-  #post-list .card:hover,
-  #post-list .post-preview:hover {
-    background-color: transparent; /* Let parent control bg */
-  }
-  
-  /* Dark mode: keep a subtle contrast (slightly lighter hover) */
-  /* Support system preference dark mode */
-  @media (prefers-color-scheme: dark) {
-    html:not([data-mode="light"]) {
-      --post-frame-gradient: linear-gradient(90deg,
-        #58B2FF 0%,
-        #5B8DEF 18%,
-        #9F63FF 36%,
-        #C26CF3 54%,
-        #FF6794 72%,
-        #FFB347 100%);
-      
-      #post-list .post-preview {
-        background: #1f1f20;
-        
-        &:hover {
-          background: #282829;
-        }
-      }
-      
-      #post-list .card-wrapper > .card,
-      #post-list .card-wrapper > .post-preview {
-        background: #1f1f20;
-      }
-      
-      #post-list .card-wrapper:hover > .card,
-      #post-list .card-wrapper:focus-within > .card,
-      #post-list .card-wrapper:hover > .post-preview,
-      #post-list .card-wrapper:focus-within > .post-preview {
-        background: #282829;
-        box-shadow: 0 6px 22px rgba(0,0,0,.55);
-      }
-    }
-  }
-  
-  /* Manual dark mode toggle */
-  html[data-mode="dark"] {
+html[data-bs-theme="dark"] {
+  --post-frame-gradient: linear-gradient(90deg,
+    #58B2FF 0%,
+    #5B8DEF 18%,
+    #9F63FF 36%,
+    #C26CF3 54%,
+    #FF6794 72%,
+    #FFB347 100%);
+}
+
+@media (prefers-color-scheme: dark) {
+  html:not([data-bs-theme="light"]) {
     --post-frame-gradient: linear-gradient(90deg,
       #58B2FF 0%,
       #5B8DEF 18%,
@@ -146,146 +41,44 @@
       #C26CF3 54%,
       #FF6794 72%,
       #FFB347 100%);
-    
-    #post-list .post-preview {
-      background: #1f1f20;
-      
-      &:hover {
-        background: #282829;
-      }
-    }
-    
-    #post-list .card-wrapper > .card,
-    #post-list .card-wrapper > .post-preview {
-      background: #1f1f20;
-    }
-    
-    #post-list .card-wrapper:hover > .card,
-    #post-list .card-wrapper:focus-within > .card,
-    #post-list .card-wrapper:hover > .post-preview,
-    #post-list .card-wrapper:focus-within > .post-preview {
-      background: #282829;
-      box-shadow: 0 6px 22px rgba(0,0,0,.55);
-    }
   }
+}
   
-  /* === Apply gradient frame to Further Reading cards === */
-  
-  /* Further Reading section cards */
+  /* === Further Reading cards: match the flat .ce-card style used site-wide === */
   #related-posts .card,
   .post-related .card,
   .related-posts .card {
     position: relative;
-    border-radius: var(--post-frame-radius);
-    background: #ffffff !important;
-    border: none !important;
-    box-shadow: 0 3px 12px rgba(0,0,0,.08) !important;
-    transition: transform .25s ease, box-shadow .25s ease !important;
-    overflow: visible;
+    border: 1px solid var(--ce-border) !important;
+    border-radius: 14px;
+    background: var(--card-bg) !important;
+    box-shadow: none !important;
+    overflow: hidden;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease !important;
   }
-  
-  /* Gradient frame for Further Reading cards */
+
+  /* Remove the theme's tint overlay and the old gradient-ring frame */
   #related-posts .card::before,
   .post-related .card::before,
   .related-posts .card::before {
-    content: "";
-    position: absolute;
-    inset: 0;
-    padding: var(--post-frame-thickness);
-    border-radius: inherit;
-    background: var(--post-frame-gradient);
-    opacity: 0;
-    transition: opacity .25s ease;
-    pointer-events: none;
-    -webkit-mask:
-      linear-gradient(#000 0 0) content-box,
-      linear-gradient(#000 0 0);
-    -webkit-mask-composite: xor;
-            mask-composite: exclude;
-    z-index: -1;
+    display: none !important;
   }
-  
-  /* Show gradient on hover */
-  #related-posts .card:hover::before,
-  .post-related .card:hover::before,
-  .related-posts .card:hover::before {
-    opacity: 1;
-  }
-  
-  /* Hover effects for Further Reading cards */
+
   #related-posts .card:hover,
   .post-related .card:hover,
   .related-posts .card:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 8px 20px rgba(0,0,0,.10) !important;
-    background: #fafafa !important;
+    transform: translateY(-3px);
+    border-color: transparent !important;
+    box-shadow: 0 14px 30px rgba(0, 0, 0, 0.12) !important;
   }
-  
-  /* Dark mode for Further Reading cards */
-  html[data-mode="dark"] #related-posts .card,
-  html[data-mode="dark"] .post-related .card,
-  html[data-mode="dark"] .related-posts .card {
-    background: #1f1f20 !important;
-  }
-  
-  html[data-mode="dark"] #related-posts .card:hover,
-  html[data-mode="dark"] .post-related .card:hover,
-  html[data-mode="dark"] .related-posts .card:hover {
-    background: #282829 !important;
-    box-shadow: 0 6px 22px rgba(0,0,0,.55) !important;
-  }
-  
-  /* System dark mode for Further Reading cards */
-  @media (prefers-color-scheme: dark) {
-    html:not([data-mode="light"]) #related-posts .card,
-    html:not([data-mode="light"]) .post-related .card,
-    html:not([data-mode="light"]) .related-posts .card {
-      background: #1f1f20 !important;
-    }
-    
-    html:not([data-mode="light"]) #related-posts .card:hover,
-    html:not([data-mode="light"]) .post-related .card:hover,
-    html:not([data-mode="light"]) .related-posts .card:hover {
-      background: #282829 !important;
-      box-shadow: 0 6px 22px rgba(0,0,0,.55) !important;
-    }
-  }
-  
-  /* If the Further Reading uses a different structure with wrappers */
-  .further-reading .card-wrapper,
-  #further-reading .card-wrapper {
-    position: relative;
-    border-radius: var(--post-frame-radius);
-  }
-  
-  .further-reading .card-wrapper::before,
-  #further-reading .card-wrapper::before {
-    content: "";
-    position: absolute;
-    inset: 0;
-    padding: var(--post-frame-thickness);
-    border-radius: inherit;
-    background: var(--post-frame-gradient);
-    opacity: 0;
-    transition: opacity .25s ease;
-    pointer-events: none;
-    -webkit-mask:
-      linear-gradient(#000 0 0) content-box,
-      linear-gradient(#000 0 0);
-    -webkit-mask-composite: xor;
-            mask-composite: exclude;
-    z-index: 1;
-  }
-  
-  .further-reading .card-wrapper:hover::before,
-  #further-reading .card-wrapper:hover::before {
-    opacity: 1;
-  }
-  
-  .further-reading .card-wrapper > .card,
-  #further-reading .card-wrapper > .card {
-    position: relative;
-    z-index: 0;
+
+  @media (prefers-reduced-motion: reduce) {
+    #related-posts .card,
+    .post-related .card,
+    .related-posts .card { transition: none !important; }
+    #related-posts .card:hover,
+    .post-related .card:hover,
+    .related-posts .card:hover { transform: none; }
   }
   
   /* === Microsoft Copilot Studio Sidebar Theme === */
@@ -417,7 +210,7 @@
   }
   
   /* Dark mode adjustments */
-  html[data-mode="dark"] {
+  html[data-bs-theme="dark"] {
     #sidebar {
       background: #1f1f1f !important;
       border-right-color: #323130 !important;
@@ -545,7 +338,7 @@
   
   /* System dark mode support for sidebar */
   @media (prefers-color-scheme: dark) {
-    html:not([data-mode="light"]) {
+    html:not([data-bs-theme="light"]) {
       #sidebar {
         background: #1f1f1f !important;
         border-right-color: #323130 !important;
@@ -698,7 +491,7 @@
       }
     }
     
-    html[data-mode="dark"] #sidebar-trigger {
+    html[data-bs-theme="dark"] #sidebar-trigger {
       background: #1f1f1f;
       border-color: #323130;
       color: #f3f2f1;
@@ -802,7 +595,7 @@
   }
   
   /* Dark mode adjustments - make colors pop even more */
-  html[data-mode="dark"] {
+  html[data-bs-theme="dark"] {
     /* Home - Brighter purple */
     #sidebar .nav-link[href="/"] i,
     #sidebar .nav-link[href="/mcscatblog/"] i,
@@ -843,7 +636,7 @@
 
   /* System dark mode - colorful icons */
   @media (prefers-color-scheme: dark) {
-    html:not([data-mode="light"]) {
+    html:not([data-bs-theme="light"]) {
       /* Home - Brighter purple */
       #sidebar .nav-link[href="/"] i,
       #sidebar .nav-link[href="/mcscatblog/"] i,
@@ -900,7 +693,7 @@
   }
   
   /* Dark mode - bottom bar icons */
-  html[data-mode="dark"] #sidebar .sidebar-bottom {
+  html[data-bs-theme="dark"] #sidebar .sidebar-bottom {
     a, button {
       i {
         color: #605e5c !important; /* Medium gray in dark mode */
@@ -995,8 +788,8 @@
 /* Algolia InstantSearch highlight styling for light and dark modes */
 
 /* Light mode highlighting */
-html:not([data-mode]),
-html[data-mode="light"] {
+html:not([data-bs-theme]),
+html[data-bs-theme="light"] {
   /* Highlighted text in search results */
   .ais-Highlight-highlighted,
   .ais-Snippet-highlighted,
@@ -1019,7 +812,7 @@ html[data-mode="light"] {
 }
 
 /* Dark mode highlighting */
-html[data-mode="dark"] {
+html[data-bs-theme="dark"] {
   .ais-Highlight-highlighted,
   .ais-Snippet-highlighted,
   mark {
@@ -1041,7 +834,7 @@ html[data-mode="dark"] {
 
 /* System preference dark mode */
 @media (prefers-color-scheme: dark) {
-  html:not([data-mode="light"]) {
+  html:not([data-bs-theme="light"]) {
     .ais-Highlight-highlighted,
     .ais-Snippet-highlighted,
     mark {
@@ -1115,7 +908,7 @@ html[data-mode="dark"] {
 }
 
 /* Dark mode (Chirpy toggle) */
-html[data-mode="dark"] {
+html[data-bs-theme="dark"] {
   .agent-edition--standard {
     color: #f0c14b;
     background-color: rgba(255, 193, 7, 0.14);
@@ -1137,7 +930,7 @@ html[data-mode="dark"] {
 
 /* Dark mode via system preference (when no explicit toggle) */
 @media (prefers-color-scheme: dark) {
-  html:not([data-mode="light"]) {
+  html:not([data-bs-theme="light"]) {
     .agent-edition--standard {
       color: #f0c14b;
       background-color: rgba(255, 193, 7, 0.14);
@@ -1156,4 +949,430 @@ html[data-mode="dark"] {
       border-color: rgba(20, 184, 166, 0.50);
     }
   }
+}
+
+/* =========================================================================
+   HOME REDESIGN — "Field guide" masthead, collections grid, uniform feed
+   Scoped entirely to .ce-* classes so the rest of the site is untouched.
+   Colors lean on the theme's own CSS variables so light/dark both adapt.
+   ========================================================================= */
+
+:root {
+  --ce-display: 'Space Grotesk', Lato, 'Microsoft Yahei', sans-serif;
+  --ce-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+  --ce-accent: #7f39fb;
+  --ce-accent-ink: #6d28d9;
+  --ce-grad: var(--post-frame-gradient, linear-gradient(135deg, #0078d4, #7f39fb 55%, #d83b73));
+  --ce-border: var(--sidebar-border-color, rgba(0, 0, 0, 0.09));
+  --ce-tile-bg: var(--card-bg, #fff);
+}
+
+:root[data-bs-theme='dark'] {
+  --ce-accent-ink: #b79bff;
+  --ce-border: rgba(255, 255, 255, 0.10);
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-bs-theme='light']) {
+    --ce-accent-ink: #b79bff;
+    --ce-border: rgba(255, 255, 255, 0.10);
+  }
+}
+
+/* ---- shared bits ---- */
+.ce-kicker {
+  font-family: var(--ce-mono);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ce-accent-ink);
+  margin: 0 0 0.75rem;
+}
+
+.ce-section-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem 1rem;
+  margin: 2.75rem 0 1.3rem;
+}
+.ce-section-head .ce-kicker { flex: 0 0 100%; margin: 0; }
+.ce-section-title {
+  font-family: var(--ce-display);
+  font-size: clamp(1.4rem, 3vw, 1.95rem);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--heading-color);
+  margin: 0 auto 0 0;
+}
+.ce-section-link {
+  font-family: var(--ce-mono);
+  font-size: 0.76rem;
+  font-weight: 500;
+  color: var(--text-muted-color);
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  white-space: nowrap;
+  transition: color 0.2s ease;
+}
+.ce-section-link:hover { color: var(--ce-accent-ink); text-decoration: none; }
+
+/* ---- hero ---- */
+.ce-hero {
+  padding: 0.75rem 0 0.5rem;
+  display: block;
+}
+.ce-hero__main {
+  max-width: 56rem;
+  min-width: 0;
+}
+.ce-hero__title {
+  font-family: var(--ce-display);
+  font-weight: 600;
+  font-size: clamp(2rem, 5.2vw, 3.25rem);
+  line-height: 1.06;
+  letter-spacing: -0.025em;
+  color: var(--heading-color);
+  margin: 0 0 1.1rem;
+}
+.ce-hero__accent {
+  background: var(--ce-grad);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+}
+.ce-hero__lede {
+  font-size: clamp(1.02rem, 2.2vw, 1.2rem);
+  line-height: 1.6;
+  color: var(--text-muted-color);
+  max-width: 60ch;
+  margin: 0 0 1.5rem;
+}
+.ce-hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+  margin-bottom: 1.35rem;
+}
+.ce-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  font-size: 0.9rem;
+  padding: 0.62rem 1.15rem;
+  border-radius: 9px;
+  text-decoration: none;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+.ce-btn i { font-size: 0.85em; }
+.ce-btn--primary {
+  background: var(--ce-accent);
+  color: #fff;
+  box-shadow: 0 4px 14px rgba(127, 57, 251, 0.24);
+}
+.ce-btn--primary:hover { transform: translateY(-1px); box-shadow: 0 7px 20px rgba(127, 57, 251, 0.36); color: #fff; text-decoration: none; }
+.ce-btn--ghost {
+  background: transparent;
+  color: var(--heading-color);
+  border-color: var(--ce-border);
+}
+.ce-btn--ghost:hover { border-color: var(--ce-accent); color: var(--ce-accent-ink); text-decoration: none; }
+.ce-hero__stats {
+  font-family: var(--ce-mono);
+  font-size: 0.76rem;
+  color: var(--text-muted-color);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0;
+}
+.ce-hero__stats .ce-dot { opacity: 0.45; }
+
+/* ---- featured section (curated posts; reuses the standard feed card) ---- */
+.ce-featured { margin-bottom: 1rem; }
+
+/* ---- collections grid (the navigability signature) ---- */
+.ce-collections { margin-bottom: 1rem; }
+.ce-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.9rem;
+}
+@media (min-width: 768px) {
+  .ce-grid { grid-template-columns: repeat(3, 1fr); gap: 1rem; }
+}
+.ce-tile {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  padding: 1.2rem;
+  border: 1px solid var(--ce-border);
+  border-radius: 14px;
+  background: var(--ce-tile-bg);
+  color: inherit;
+  text-decoration: none;
+  overflow: hidden;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+.ce-tile:hover {
+  transform: translateY(-3px);
+  border-color: transparent;
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.12);
+  text-decoration: none;
+}
+.ce-tile__top { display: flex; align-items: center; justify-content: space-between; }
+.ce-tile__icon {
+  width: 42px;
+  height: 42px;
+  border-radius: 11px;
+  background: color-mix(in srgb, var(--tile-color, #9F63FF) 14%, transparent);
+  color: var(--tile-color, #9F63FF);
+  display: grid;
+  place-items: center;
+  font-size: 1.05rem;
+}
+.ce-tile__title {
+  font-family: var(--ce-display);
+  font-size: 1.1rem;
+  font-weight: 600;
+  line-height: 1.25;
+  color: var(--heading-color);
+  margin: 0;
+}
+.ce-tile__blurb {
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: var(--text-muted-color);
+  margin: 0;
+  flex-grow: 1;
+}
+.ce-tile__count {
+  font-family: var(--ce-mono);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  color: var(--text-muted-color);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin-top: 0.2rem;
+  transition: color 0.2s ease;
+}
+.ce-tile:hover .ce-tile__count { color: var(--heading-color); }
+
+/* ---- latest feed with uniform thumbnails ---- */
+.ce-feed {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.25rem;
+}
+@media (min-width: 640px) {
+  .ce-feed { grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); }
+}
+.ce-feed-empty {
+  font-family: var(--ce-mono);
+  font-size: 0.85rem;
+  color: var(--text-muted-color);
+  padding: 1.5rem 0;
+  margin: 0;
+}
+.ce-feed-empty a { color: var(--ce-accent-ink); text-decoration: none; }
+.ce-feed-empty a:hover { text-decoration: underline; }
+.ce-card {
+  display: flex;
+  border: 1px solid var(--ce-border);
+  border-radius: 14px;
+  overflow: hidden;
+  background: var(--card-bg);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+.ce-card:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.12);
+  border-color: transparent;
+}
+.ce-card--pinned { border-color: rgba(127, 57, 251, 0.35); }
+.ce-card__link {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  color: inherit;
+  text-decoration: none;
+}
+.ce-card__link:hover { text-decoration: none; }
+
+.ce-thumb {
+  position: relative;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  background: var(--sidebar-bg);
+  border-bottom: 1px solid var(--ce-border);
+}
+.ce-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transition: transform 0.4s ease;
+}
+.ce-card:hover .ce-thumb img { transform: scale(1.04); }
+.ce-thumb::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.05);
+  pointer-events: none;
+}
+.ce-thumb--placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.65rem;
+  background:
+    radial-gradient(130% 130% at 12% 0%, rgba(127, 57, 251, 0.12), transparent 55%),
+    var(--sidebar-bg);
+}
+.ce-thumb__chip {
+  width: 48px;
+  height: 48px;
+  border-radius: 12px;
+  background: var(--ce-grad);
+  color: #fff;
+  display: grid;
+  place-items: center;
+  font-size: 1.2rem;
+  box-shadow: 0 4px 12px rgba(127, 57, 251, 0.28);
+}
+.ce-thumb__label {
+  font-family: var(--ce-mono);
+  font-size: 0.66rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted-color);
+}
+
+.ce-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1rem 1.1rem 1.1rem;
+  flex-grow: 1;
+}
+.ce-card__eyebrow {
+  font-family: var(--ce-mono);
+  font-size: 0.66rem;
+  font-weight: 600;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--ce-accent-ink);
+  margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.ce-card__title {
+  font-family: var(--ce-display);
+  font-size: 1.1rem;
+  font-weight: 600;
+  line-height: 1.3;
+  color: var(--heading-color);
+  margin: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.ce-card__excerpt {
+  font-size: 0.85rem;
+  line-height: 1.55;
+  color: var(--text-muted-color);
+  margin: 0;
+  flex-grow: 1;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.ce-card__meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 0.4rem;
+  font-family: var(--ce-mono);
+  font-size: 0.72rem;
+  color: var(--text-muted-color);
+}
+.ce-card__meta i { margin-right: 0.35rem; }
+.ce-card__top {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.ce-card__top .ce-card__eyebrow { min-width: 0; }
+.ce-card__pin {
+  color: var(--ce-accent-ink);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  margin-left: auto;
+  flex-shrink: 0;
+  font-family: var(--ce-mono);
+  font-size: 0.66rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+/* ---- a11y ---- */
+.ce-btn:focus-visible,
+.ce-tile:focus-visible,
+.ce-card__link:focus-visible,
+.ce-section-link:focus-visible {
+  outline: 2px solid var(--ce-accent);
+  outline-offset: 3px;
+  border-radius: 10px;
+}
+@media (prefers-reduced-motion: reduce) {
+  .ce-tile, .ce-card, .ce-thumb img, .ce-tile__count i, .ce-btn { transition: none !important; }
+  .ce-tile:hover, .ce-card:hover { transform: none; }
+  .ce-card:hover .ce-thumb img { transform: none; }
+}
+
+/* Hide the redundant mobile topbar title on the home page (it duplicates the hero). */
+body.home #topbar-title { display: none !important; }
+
+/* === Collapsible sidebar at all widths ===
+   Below 850px Chirpy already renders the sidebar off-canvas with a hamburger
+   trigger + backdrop mask. We extend that behaviour to >= 850px so the left
+   bar is collapsed by default everywhere and slides in via the existing
+   trigger (reusing the theme's JS + #mask), keeping content full-width. */
+@media (min-width: 850px) {
+  #sidebar {
+    transition: transform 0.4s ease;
+    transform: translateX(-100%);
+  }
+  html[sidebar-display] #sidebar,
+  body[sidebar-display] #sidebar { transform: translateX(0); }
+  #main-wrapper { margin-left: 0 !important; }
+  #topbar-wrapper { left: 0 !important; }
+
+  /* Reveal + left-align the hamburger, keep the search box on the right */
+  #topbar { justify-content: flex-start !important; }
+  #sidebar-trigger { display: block !important; order: -1; margin-right: 0.5rem; }
+  #search { margin-left: auto !important; }
+
+  /* Subtle backdrop when the drawer is open */
+  body[sidebar-display] #mask { background: rgba(0, 0, 0, 0.32); }
 }


### PR DESCRIPTION
## What & why

Reworks **The Custom Engine** home page to be more navigable and professional. Content is organized into bands — masthead hero → **Featured** → **Topics** grid → **Latest** feed — built from uniform post cards using a scoped `.ce-*` design system that adapts to light/dark.

## Changes

- **New home layout & includes:** `home.html`, `home-hero.html`, `home-featured.html`, `home-collections.html`, `home-post-card.html`, and a feed-aware `post-paginator.html` (excludes pinned posts so the pager caps at the real number of feed pages).
- **Content reorg:** flattened 79 posts to a single **topic** category across 9 curated collections; added `_data/collections.yml` (slug-keyed icon/color/blurb style map).
- **Dark-mode fix:** sidebar + Algolia search highlight now track the resolved theme (`data-mode` → `data-bs-theme`), so the off-canvas drawer is no longer white-on-dark on manual toggle.
- **Type:** added Space Grotesk (display) + JetBrains Mono (labels).

## Verification

Previewed locally on a Jekyll server in **light and dark**, on **desktop and mobile (390px)**:

- 0 horizontal overflow on all page types (home, post, categories, tags, archives, about) × both themes
- Cards stack cleanly to single/2-column on mobile; hero headline scales, gradient intact
- Pagination shows the correct page count and prev/next states; page beyond the feed shows a graceful empty state
- Off-canvas nav works in both themes (drawer is dark in dark mode)

Category counts after restructure: channels 15, mcp 14, knowledge 10, orchestration 9, automation 9, testing 6, alm 6, authentication 3, agents-sdk 3 (75 published total).

🤖 Generated with Copilot CLI