### PR TITLE
Fix mobile search icon alignment

### DIFF
--- a/assets/css/jekyll-theme-chirpy.scss
+++ b/assets/css/jekyll-theme-chirpy.scss
@@ -1352,6 +1352,7 @@ html[data-bs-theme="dark"] {
 
 /* Hide the redundant mobile topbar title on the home page (it duplicates the hero). */
 body.home #topbar-title { display: none !important; }
+body.home #search-trigger { margin-left: auto; }
 
 /* === Collapsible sidebar at all widths ===
    Below 850px Chirpy already renders the sidebar off-canvas with a hamburger


### PR DESCRIPTION
## Summary
- Keep the home-page search trigger right-aligned on mobile
- Prevent the magnifying glass from being covered by the fixed hamburger button

## Checklist
- [x] Local server renders correctly (`./tools/run.sh`)
- [x] Jekyll build succeeds