### PR TITLE
Fix command injection in post metadata hook

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gem "jekyll-theme-chirpy", "~> 7.3", ">= 7.3.1"
 
 gem "html-proofer", "~> 5.0", group: :test
+gem "minitest", "~> 5.0", group: :test
 
 group :jekyll_plugins do
   gem 'jekyll-target-blank'

--- a/_plugins/posts-lastmod-hook.rb
+++ b/_plugins/posts-lastmod-hook.rb
@@ -2,13 +2,37 @@
 #
 # Check for changed posts
 
-Jekyll::Hooks.register :posts, :post_init do |post|
+require 'open3'
 
-  commit_num = `git rev-list --count HEAD "#{ post.path }"`
+module PostsLastmodHook
+  module_function
 
-  if commit_num.to_i > 1
-    lastmod_date = `git log -1 --pretty="%ad" --date=iso "#{ post.path }"`
-    post.data['last_modified_at'] = lastmod_date
+  def apply(post)
+    commit_num = git_output!('rev-list', '--count', 'HEAD', path: post.path)
+
+    return unless commit_num.to_i > 1
+
+    post.data['last_modified_at'] = git_output!(
+      'log',
+      '-1',
+      '--pretty=%ad',
+      '--date=iso',
+      path: post.path
+    ).strip
   end
 
+  def git_output!(*arguments, path:)
+    stdout, stderr, status = Open3.capture3('git', *arguments, '--', path)
+    return stdout if status.success?
+
+    message = "git #{arguments.first} failed for #{path.inspect} (exit #{status.exitstatus})"
+    details = stderr.strip
+    message = "#{message}: #{details}" unless details.empty?
+
+    raise Jekyll::Errors::FatalException, message
+  end
+end
+
+Jekyll::Hooks.register :posts, :post_init do |post|
+  PostsLastmodHook.apply(post)
 end

--- a/test/posts_lastmod_hook_test.rb
+++ b/test/posts_lastmod_hook_test.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'jekyll'
+require 'minitest/autorun'
+require 'open3'
+require 'tmpdir'
+
+require_relative '../_plugins/posts-lastmod-hook'
+
+class PostsLastmodHookTest < Minitest::Test
+  Post = Struct.new(:path, :data)
+
+  def test_metacharacters_are_literal_and_last_modified_requires_two_commits
+    Dir.mktmpdir do |repository|
+      Dir.chdir(repository) do
+        initialize_repository
+
+        post_path = '_posts/2026-01-01-$(touch shell-owned)"; touch quote-owned; #.md'
+        FileUtils.mkdir_p('_posts')
+        File.write(post_path, "first version\n")
+        commit(post_path, 'Add post')
+
+        post = Post.new(post_path, {})
+        PostsLastmodHook.apply(post)
+
+        refute post.data.key?('last_modified_at')
+        refute File.exist?('shell-owned')
+        refute File.exist?('quote-owned')
+
+        File.write(post_path, "second version\n")
+        commit(post_path, 'Update post')
+
+        PostsLastmodHook.apply(post)
+
+        assert_match(/\A\d{4}-\d{2}-\d{2}/, post.data.fetch('last_modified_at'))
+        refute File.exist?('shell-owned')
+        refute File.exist?('quote-owned')
+      end
+    end
+  end
+
+  def test_git_failure_stops_the_build_with_a_clear_error
+    Dir.mktmpdir do |directory|
+      Dir.chdir(directory) do
+        error = assert_raises(Jekyll::Errors::FatalException) do
+          PostsLastmodHook.apply(Post.new('_posts/2026-01-01-example.md', {}))
+        end
+
+        assert_includes error.message, 'git rev-list failed'
+        assert_includes error.message, 'exit 128'
+      end
+    end
+  end
+
+  private
+
+  def initialize_repository
+    git!('init', '--quiet')
+    git!('config', 'user.email', 'test@example.com')
+    git!('config', 'user.name', 'Test Author')
+  end
+
+  def commit(path, message)
+    git!('add', '--', path)
+    git!('commit', '--quiet', '-m', message)
+  end
+
+  def git!(*arguments)
+    _stdout, stderr, status = Open3.capture3('git', *arguments)
+    return if status.success?
+
+    raise "git #{arguments.first} failed: #{stderr}"
+  end
+end


### PR DESCRIPTION
## Summary
- replace shell-interpolated Git commands with argument-vector execution
- treat post filenames literally with a Git `--` path separator
- fail clearly on Git errors and add malicious-filename regression coverage

## Checklist
- [x] Shell-injection regression tests pass
- [x] Full Jekyll site build succeeds
- [x] Post-specific content and image checks are not applicable