### PR TITLE
Revisions to the Agent Memory draft: commit to the techniques lane, address review feedback

### DIFF
--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -138,3 +138,7 @@ emdarcy:
 kaashyapmurali:
   name: Kaashyap Murali
   avatar: https://github.com/kaashyapmurali.png
+
+misroka:
+  name: Michal Sroka
+  avatar: https://github.com/misroka.png

--- a/_includes/metadata-hook.html
+++ b/_includes/metadata-hook.html
@@ -1,1 +1,8 @@
 <meta name="algolia-site-verification"  content="46C247BC7C8677B2" />
+
+{% if page.authors %}
+  {% for author in page.authors offset: 1 %}
+    {% assign author_name = site.data.authors[author].name | default: author %}
+    <meta name="author" content="{{ author_name | xml_escape }}">
+  {% endfor %}
+{% endif %}

--- a/_plugins/multi-author-seo.rb
+++ b/_plugins/multi-author-seo.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "jekyll-seo-tag"
+
+module MultiAuthorSeo
+  module PageDrop
+    def seo_authors
+      entries = page["authors"]
+      return [] unless entries.is_a?(Array)
+
+      authors_data = site.data["authors"]
+
+      entries.filter_map do |entry|
+        data = authors_data.is_a?(Hash) ? authors_data[entry] : nil
+        name = data.is_a?(Hash) ? data["name"] : entry
+        next if name.to_s.empty?
+
+        author = {
+          "@type" => "Person",
+          "name" => name
+        }
+        author["url"] = data["url"] if data.is_a?(Hash) && data["url"]
+        author
+      end
+    end
+  end
+
+  module JsonLdDrop
+    def author
+      authors = page_drop.seo_authors
+      return super unless authors.length > 1
+
+      authors
+    end
+  end
+end
+
+Jekyll::SeoTag::Drop.prepend(MultiAuthorSeo::PageDrop)
+Jekyll::SeoTag::JSONLDDrop.prepend(MultiAuthorSeo::JsonLdDrop)

--- a/_posts/2026-08-01-agent-memory.md
+++ b/_posts/2026-08-01-agent-memory.md
@@ -4,9 +4,9 @@ agent_edition: github-copilot
 title: "Agent Memory: How Agents Carry Knowledge Across Conversations"
 date: 2026-08-01
 categories: [copilot-studio, agents]
-tags: [copilot-studio, agent-memory, agent-development, best-practices, evals, governance]
-description: "Large language models are stateless. Here's how agent memory in Copilot Studio carries knowledge across conversations: short-term and long-term memory, the three kinds of long-term memory, reflection, and the guardrails that keep it trustworthy."
-author: kaashyapmurali
+tags: [copilot-studio, agent-memory, agent-development, best-practices, evals, sandbox]
+description: "Large language models are stateless. Here's how agent memory in Copilot Studio carries knowledge across conversations: short-term and long-term memory, the three kinds of long-term memory, reflection, and how we check that it actually works."
+authors: [kaashyapmurali, misroka]
 image:
   path: /assets/posts/agent-memory/header.png
   alt: "Agent memory: three sessions connected to a durable memory store"
@@ -81,9 +81,11 @@ Agent memory in Copilot Studio is built on a deliberately simple idea: **memory 
 
 Two consequences follow. Recall doesn't require exotic infrastructure. The agent looks things up much the way you would, opening an index and navigating to the relevant section. And correcting memory is a normal edit rather than a re-indexing operation, which matters enormously for the "cross it out because it is no longer true" problem.
 
+Being readable is only useful if someone can actually go and read it, so memory is not buried inside the runtime. When an agent has memory enabled, the first time you talk to it you are told so, and pointed at a memory page in Copilot Studio where what it has learned about you can be reviewed and deleted.
+
 ### Scoped, separated, and sandboxed
 
-Not all memory belongs to the same person. What one user told an agent about their own preferences is very different from a pattern the agent learned about how a business process works, which is different again from knowledge owned by the whole organization. Copilot Studio keeps these in **distinct scopes**, and those scopes are **separate stores, not labels on a shared one**.
+Not all memory belongs to the same person. What one user told an agent about their own preferences is very different from a pattern the agent learned about how a business process works, which is different again from knowledge owned by the whole organization. Copilot Studio keeps these in **distinct scopes**, and those scopes are **separate stores, not labels on a shared one**. Each store's address is derived from the scope it belongs to, so a session can only ever address the stores it was entitled to. There is no shared pool to accidentally over-read from.
 
 Each conversation then runs inside an **isolated sandbox**, the same kind of [agent sandbox]({% post_url 2026-07-20-copilot-studio-agent-sandbox %}) that gives an agent a private place to work. Memory is mounted into that sandbox for the life of the turn with an access mode attached. So the question "what can this agent reach right now?" has a concrete answer: exactly the stores it was entitled to, at exactly the permissions they were mounted with. Anything else simply isn't there to reach.
 
@@ -99,9 +101,9 @@ flowchart TB
     USR -- "mounted, read-write" --> SB
 ```
 {% endraw %}
-_Privacy by construction. Because separation is enforced by where memory lives and how it is mounted, least-privilege access is a property of the system rather than something the model has to be trusted to respect._
+_Isolation by construction. Because separation is enforced by where memory lives and how it is mounted, least-privilege access is a property of the system rather than something the model has to be trusted to respect._
 
-That is the point of building it this way. Privacy and compliance become properties of the architecture rather than promises about behavior.
+That is the point of building it this way: what an agent can reach is decided by the architecture, not by asking the model to behave. The wider story here, how memory is governed, what makers and admins control, and how organizations reason about it at scale, is a big enough topic that it deserves its own post rather than a section in this one.
 
 ### Reflection: turning experience into knowledge
 
@@ -121,35 +123,21 @@ flowchart LR
 ```
 _The memory loop. Forming memory is only half the system. Keeping it true is the other half: anything kept must also be capable of being corrected or dropped._
 
-## Guardrails come first, not last
-
-Memory can mislead as easily as it can help. A stale fact repeated confidently is worse than no fact at all, and durable memory about people is durable *personal data*. So the controls are part of the design, not a hardening pass bolted on afterward.
-
-| Control | What it means in practice |
-|---|---|
-| Consent and control | Whether an agent uses memory, and at which scopes, is an explicit decision rather than an implicit behavior, with controls for the maker who builds the agent and for the people who talk to it. |
-| Isolation by construction | Scopes are separate stores, addressed per tenant, environment, agent, and user, and surfaced to a session only when it is entitled to them. |
-| Least privilege on write | Live turns cannot rewrite broader-scope memory. Anything that would widen a memory's audience is treated as a promotion that has to be earned, not a side effect. |
-| Inspectable and reversible | Memory is human-readable and versioned, so it can be reviewed, corrected, or deleted, including deletion initiated by the person it describes. |
-| Staged rollout | Capabilities widen only after they clear quality, safety, privacy, and cost gates, and every step retains a kill switch. |
-
-Compliance is a first-class requirement rather than an afterthought: memory derived from a person's conversations must be discoverable and deletable by that person, and memory meant to describe a *process* must not quietly accumulate facts about *people*.
-
 ## Trusted, but also verified
 
-Adding memory to an agent is a change you have to prove, because the failure modes are quiet.
+Everything above is a claim about how the system behaves, and claims about memory are easy to make and hard to keep. So before any of this widens to more customers, our engineering and data science teams have to show it holds. That work is ours, not something we hand to makers to figure out on their own.
 
 > An agent with a bad memory does not crash. It just becomes confidently wrong.
 {: .prompt-warning }
 
-So memory is evaluated against the ways it can go wrong, not only the ways it can help. Among the behaviors we hold agents to:
+That is what makes memory worth testing carefully: the failure modes are quiet. So we evaluate memory against the ways it can go wrong, not only the ways it can help. Among the behaviors we hold agents to:
 
 - **Recall.** Days later, in a brand new conversation, does the agent still know what it was told?
 - **Negative recall.** When memory holds something stale or simply wrong, does the agent catch it, or repeat it with confidence?
 - **Abstention.** When something was never actually said, does the agent say it doesn't know? An agent that trades correct refusals for plausible guesses has become less trustworthy, not more.
 - **Hallucination.** Does having a memory tempt the model into inventing detail that was never in it?
 
-Pinning down behaviors this nuanced is its own discipline. If you want to go deeper on that, we wrote about [scoring agent behavior with LLMs]({% post_url 2026-06-26-better-llm-scoring %}). Memory earns a wider audience only when it clearly helps on recall without costing the agent its willingness to say "I don't know."
+Pinning down behaviors this nuanced is its own discipline. If you want to go deeper on that, we wrote about [scoring agent behavior with LLMs]({% post_url 2026-06-26-better-llm-scoring %}). The bar is simple: memory has to clearly help on recall without costing the agent its willingness to say "I don't know."
 
 > A memory system isn't good because it remembers more. It's good because it remembers the right things, and knows what it doesn't know.
 

--- a/_posts/2026-08-01-agent-memory.md
+++ b/_posts/2026-08-01-agent-memory.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 agent_edition: github-copilot
-title: "Agent Memory: How Agents Carry Knowledge Across Conversations"
+title: "Memory in Copilot Studio: How Agents Carry Knowledge Across Conversations"
 date: 2026-08-01
 categories: [copilot-studio, agents]
 tags: [copilot-studio, agent-memory, agent-development, best-practices, evals, sandbox]


### PR DESCRIPTION
## Revisions to the Agent Memory draft (#355)

Builds on @adilei's draft in #355 and works through the review feedback. Branched off `adilei-post-agent-memory` so the original draft stays intact.

### The headline call: commit to the techniques lane

Per the "distill the purpose and voice" feedback, this commits to the **how it's built under the hood** story and defers governance to a follow-up post. That resolves the persona drift and both redundancies flagged in review.

- Removed the **"Guardrails come first, not last"** section (control table + compliance paragraph) and replaced it with an explicit pointer to a governance follow-up.
- This also clears both overlaps called out: the *Isolation by construction* row restated the sandbox section, and the *Staged rollout* row duplicated Reflection's staged-rollout tail. The diagram caption is now **"Isolation by construction"**, absorbing that framing.
- Front matter follows the same call: dropped the now-inaccurate `governance` tag (added `sandbox`, which should also help Further Reading surface the sandbox post) and rewrote the `description`.

### Inline comments

**Line 80 (blob storage + how to inspect)** — Adopted the underlying point, declined both specifics.

The fair catch was that the post asserted memory is inspectable without saying *by whom* or *how*. Now addressed: users are told on first contact and pointed at a memory page in Copilot Studio.

Two notes on the specifics, though:
- *"Inspect it by conversing with the agent"* is not accurate enough to publish. The agent can read its own memory files, so it will answer, but that path is model-mediated: it can paraphrase, omit, or misreport. It isn't an authoritative view and definitely isn't a compliance-grade audit or deletion path. The management page is the real surface, and the stronger claim.
- **Blob storage** is deliberately left out. It's the most perishable detail in the post, an implementation choice that buys the reader nothing. "Memory is human-readable content" is the durable claim; naming the storage backend just dates the post.

**Line 86 (what "separate stores" means)** — Added, kept at a durable altitude.

Each store's address is derived from the scope it belongs to, so a session can only ever address the stores it was entitled to; there's no shared pool to over-read from. That answers the real question (genuinely separate vs. a filtered view over shared storage) without naming infrastructure that may change.

**Line 133 (user deletion guarantee)** — Corrected, and you were half right.

A first-class user surface *does* exist for user-scope memory, so it isn't a total gap. But the claim as written was too broad: it implied a uniform deletion right across every scope, and agent-scope memory is maker-owned. The claim is now scoped to what the agent has learned about that individual user.

Your sharper point stands and isn't answered here: there's no cross-agent view of "everything stored about me." That's real, and it belongs in the governance follow-up rather than a half-answer in this post.

**Line 140 (who has to prove it?)** — Fixed.

It's Microsoft engineering and data science validating the platform, not makers validating their own agents. Rather than patch the one sentence, the section opening now establishes that once, up front.

### Housekeeping

- Credited **Michal Sroka** as co-author (`authors: [kaashyapmurali, misroka]`, added to `_data/authors.yml`), matching the source article byline.
- Retitled to **"Memory in Copilot Studio: How Agents Carry Knowledge Across Conversations"** to lead with the product.

### Not done

- A series framing for this post is under discussion with @adilei and Michal; nothing added yet.
- Governance/compliance content is deferred rather than deleted. It's enough material for its own post.

@adilei over to you.
